### PR TITLE
Add GitHub Action to run feed generators hourly

### DIFF
--- a/.github/workflows/run_feeds.yml
+++ b/.github/workflows/run_feeds.yml
@@ -1,0 +1,30 @@
+name: Run Feeds
+
+on:
+  schedule:
+    - cron: "0 * * * *"  # Runs every hour
+  workflow_dispatch:
+
+jobs:
+  run-feeds:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Run all feed generators
+        run: |
+          source venv/bin/activate
+          python feed_generators/run_all_feeds.py

--- a/feed_generators/run_all_feeds.py
+++ b/feed_generators/run_all_feeds.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+import logging
+
+# Set up logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+def run_all_feeds():
+    """Run all Python scripts in the feed_generators directory."""
+    feed_generators_dir = os.path.dirname(os.path.abspath(__file__))
+    for filename in os.listdir(feed_generators_dir):
+        if filename.endswith(".py") and filename != os.path.basename(__file__):
+            script_path = os.path.join(feed_generators_dir, filename)
+            logger.info(f"Running script: {script_path}")
+            result = subprocess.run(["python", script_path], capture_output=True, text=True)
+            if result.returncode == 0:
+                logger.info(f"Successfully ran script: {script_path}")
+            else:
+                logger.error(f"Error running script: {script_path}\n{result.stderr}")
+
+if __name__ == "__main__":
+    run_all_feeds()


### PR DESCRIPTION
Add a script to run all feed generators and a GitHub Actions workflow to execute it hourly.

* **Add `feed_generators/run_all_feeds.py`**
  - Create a script to iterate through all Python files in the `feed_generators` directory and run them.
  - Set up logging to capture the output of each script execution.

* **Add `.github/workflows/run_feeds.yml`**
  - Create a GitHub Actions workflow to run the `feed_generators/run_all_feeds.py` script every hour.
  - Set up the workflow to check out the repository, set up Python, install dependencies, and run the feed generators script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Olshansk/rss-feeds/pull/1?shareId=daf74971-30c8-4825-8157-44cb3b85a533).

---

This was my prompt in https://copilot-workspace.githubnext.com/:


There are a handful of python file under `feed_generators` to create feeds under `feeds`.

Just one for now:

```bash
.
├── LICENSE
├── Makefile
├── README.md
├── feed_generators
│   └── ollama_blog.py
├── feeds
│   └── feed_ollama.xml
```

I need an hourly github action (i.e. a corn job) that iterates through each of the python files and runs them one by one.