### PR TITLE
DRY: Extract shared utilities, standardize field names across all generators

### DIFF
--- a/.github/workflows/run_feeds.yml
+++ b/.github/workflows/run_feeds.yml
@@ -37,6 +37,7 @@ jobs:
           uv run feed_generators/run_all_feeds.py --skip-selenium
 
       - name: Commit and push feeds
+        if: github.ref == 'refs/heads/main'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/run_selenium_feeds.yml
+++ b/.github/workflows/run_selenium_feeds.yml
@@ -43,6 +43,7 @@ jobs:
           uv run feed_generators/run_all_feeds.py --selenium-only
 
       - name: Commit and push feeds
+        if: github.ref == 'refs/heads/main'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'

--- a/feed_generators/anthropic_changelog_claude_code.py
+++ b/feed_generators/anthropic_changelog_claude_code.py
@@ -1,37 +1,21 @@
-import logging
 import re
-from pathlib import Path
 
-import requests
 from feedgen.feed import FeedGenerator
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
-logger = logging.getLogger(__name__)
+from utils import fetch_page, save_rss_feed, setup_feed_links, setup_logging
 
+logger = setup_logging()
 
-def get_project_root():
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
+FEED_NAME = "anthropic_changelog_claude_code"
+BLOG_URL = "https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md"
 
 
 def fetch_changelog_content(
     url="https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md",
 ):
     try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
+        return fetch_page(url)
+    except Exception as e:
         logger.error(f"Error fetching changelog content: {str(e)}")
         raise
 
@@ -104,22 +88,17 @@ def parse_changelog_markdown(markdown_content, max_versions=50):
         raise
 
 
-def generate_rss_feed(items, feed_name="anthropic_changelog_claude_code"):
+def generate_rss_feed(items, feed_name=FEED_NAME):
     try:
         fg = FeedGenerator()
         fg.title("Claude Code Changelog")
         fg.description("Version updates and changes from Claude Code CHANGELOG.md")
-        fg.link(href="https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md")
+        setup_feed_links(fg, BLOG_URL, feed_name)
         fg.language("en")
 
         fg.author({"name": "Anthropic"})
         fg.logo("https://www.anthropic.com/images/icons/apple-touch-icon.png")
         fg.subtitle("Claude Code Changelog")
-        fg.link(
-            href="https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md",
-            rel="alternate",
-        )
-        fg.link(href=f"https://anthropic.com/feed_{feed_name}.xml", rel="self")
 
         # feedgen reverses order, so reverse items to maintain newest-first
         for item in reversed(items):
@@ -138,19 +117,7 @@ def generate_rss_feed(items, feed_name="anthropic_changelog_claude_code"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="anthropic_changelog_claude_code"):
-    try:
-        feeds_dir = ensure_feeds_directory()
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(feed_name="anthropic_changelog_claude_code"):
+def main(feed_name=FEED_NAME):
     try:
         markdown_content = fetch_changelog_content()
         items = parse_changelog_markdown(markdown_content)
@@ -160,7 +127,7 @@ def main(feed_name="anthropic_changelog_claude_code"):
             return False
 
         feed = generate_rss_feed(items, feed_name)
-        output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, feed_name)
 
         logger.info(f"Successfully generated RSS feed with {len(items)} items")
         return True

--- a/feed_generators/anthropic_eng_blog.py
+++ b/feed_generators/anthropic_eng_blog.py
@@ -1,40 +1,29 @@
-import requests
-from bs4 import BeautifulSoup
+import re
 from datetime import datetime
+
 import pytz
+from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 
-from utils import sort_posts_for_feed
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+)
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+logger = setup_logging()
 
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
+FEED_NAME = "anthropic_engineering"
+BLOG_URL = "https://www.anthropic.com/engineering"
 
 
-def fetch_engineering_content(url="https://www.anthropic.com/engineering"):
+def fetch_engineering_content(url=BLOG_URL):
     """Fetch engineering page content from Anthropic's website."""
     try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
+        return fetch_page(url)
+    except Exception as e:
         logger.error(f"Error fetching engineering content: {str(e)}")
         raise
 
@@ -71,8 +60,6 @@ def parse_engineering_html(html_content):
 
         # Extract article data from the escaped JSON in the Next.js script
         # Pattern matches: publishedOn, slug, title, and summary fields
-        import re
-
         pattern = r'\\"publishedOn\\":\\"([^"]+?)\\",\\"slug\\":\{[^}]*?\\"current\\":\\"([^"]+?)\\"'
         matches = re.findall(pattern, script_content)
 
@@ -134,21 +121,19 @@ def parse_engineering_html(html_content):
         raise
 
 
-def generate_rss_feed(articles, feed_name="anthropic_engineering"):
+def generate_rss_feed(articles, feed_name=FEED_NAME):
     """Generate RSS feed from engineering articles."""
     try:
         fg = FeedGenerator()
         fg.title("Anthropic Engineering Blog")
         fg.description("Latest engineering articles and insights from Anthropic's engineering team")
-        fg.link(href="https://www.anthropic.com/engineering")
+        setup_feed_links(fg, BLOG_URL, feed_name)
         fg.language("en")
 
         # Set feed metadata
         fg.author({"name": "Anthropic Engineering Team"})
         fg.logo("https://www.anthropic.com/images/icons/apple-touch-icon.png")
         fg.subtitle("Inside the team building reliable AI systems")
-        fg.link(href="https://www.anthropic.com/engineering", rel="alternate")
-        fg.link(href=f"https://anthropic.com/engineering/feed_{feed_name}.xml", rel="self")
 
         # Sort articles for correct feed order (newest first in output)
         articles_sorted = sort_posts_for_feed(articles, date_field="date")
@@ -171,26 +156,7 @@ def generate_rss_feed(articles, feed_name="anthropic_engineering"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="anthropic_engineering"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        # Ensure feeds directory exists and get its path
-        feeds_dir = ensure_feeds_directory()
-
-        # Create the output file path
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-
-        # Save the feed
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(feed_name="anthropic_engineering"):
+def main(feed_name=FEED_NAME):
     """Main function to generate RSS feed from Anthropic's engineering page."""
     try:
         # Fetch engineering content
@@ -207,7 +173,7 @@ def main(feed_name="anthropic_engineering"):
         feed = generate_rss_feed(articles, feed_name)
 
         # Save feed to file
-        output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, feed_name)
 
         logger.info(f"Successfully generated RSS feed with {len(articles)} articles")
         return True

--- a/feed_generators/anthropic_news_blog.py
+++ b/feed_generators/anthropic_news_blog.py
@@ -1,137 +1,32 @@
 import argparse
-import json
-import logging
 import time
 import xml.etree.ElementTree as ET
-from datetime import datetime, timedelta
-from pathlib import Path
+from datetime import datetime
 
 import pytz
-import undetected_chromedriver as uc
 from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
-from utils import sort_posts_for_feed
+from utils import (
+    deserialize_entries,
+    load_cache,
+    merge_entries,
+    save_cache,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    setup_selenium_driver,
+    sort_posts_for_feed,
+    stable_fallback_date,
+)
 
 FEED_NAME = "anthropic_news"
 BLOG_URL = "https://www.anthropic.com/news"
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
-logger = logging.getLogger(__name__)
-
-
-def stable_fallback_date(identifier):
-    """Generate a stable date from a URL or title hash.
-
-    This prevents RSS readers from seeing entries as 'new' when date
-    extraction fails intermittently.
-    """
-    hash_val = abs(hash(identifier)) % 730  # ~2 years of days
-    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
-    return epoch + timedelta(days=hash_val)
-
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def get_cache_file():
-    """Get the cache file path."""
-    cache_dir = get_project_root() / "cache"
-    cache_dir.mkdir(exist_ok=True)
-    return cache_dir / f"{FEED_NAME}_posts.json"
-
-
-def load_cache():
-    """Load existing cache or return empty structure."""
-    cache_file = get_cache_file()
-    if cache_file.exists():
-        with open(cache_file, "r") as f:
-            data = json.load(f)
-            logger.info(f"Loaded cache with {len(data.get('articles', []))} articles")
-            return data
-    logger.info("No cache file found, will do full fetch")
-    return {"last_updated": None, "articles": []}
-
-
-def save_cache(articles):
-    """Save articles to cache file."""
-    cache_file = get_cache_file()
-    # Convert datetime objects to ISO strings for JSON serialization
-    serializable_articles = []
-    for article in articles:
-        article_copy = article.copy()
-        if isinstance(article_copy.get("date"), datetime):
-            article_copy["date"] = article_copy["date"].isoformat()
-        serializable_articles.append(article_copy)
-
-    data = {
-        "last_updated": datetime.now(pytz.UTC).isoformat(),
-        "articles": serializable_articles,
-    }
-    with open(cache_file, "w") as f:
-        json.dump(data, f, indent=2)
-    logger.info(f"Saved cache with {len(articles)} articles to {cache_file}")
-
-
-def deserialize_articles(articles):
-    """Convert cached articles back to proper format with datetime objects."""
-    result = []
-    for article in articles:
-        article_copy = article.copy()
-        if isinstance(article_copy.get("date"), str):
-            try:
-                article_copy["date"] = datetime.fromisoformat(article_copy["date"])
-            except ValueError:
-                article_copy["date"] = stable_fallback_date(
-                    article_copy.get("link", "")
-                )
-        result.append(article_copy)
-    return result
-
-
-def merge_articles(new_articles, cached_articles):
-    """Merge new articles into cache, dedupe by link, sort by date desc."""
-    existing_links = {a["link"] for a in cached_articles}
-    merged = list(cached_articles)
-
-    added_count = 0
-    for article in new_articles:
-        if article["link"] not in existing_links:
-            merged.append(article)
-            existing_links.add(article["link"])
-            added_count += 1
-
-    logger.info(f"Added {added_count} new articles to cache")
-
-    # Sort for correct feed order (newest first in output)
-    return sort_posts_for_feed(merged, date_field="date")
-
-
-def setup_selenium_driver():
-    """Set up Selenium WebDriver with undetected-chromedriver."""
-    options = uc.ChromeOptions()
-    options.add_argument("--headless")
-    options.add_argument("--window-size=1920,1080")
-    options.add_argument("--disable-blink-features=AutomationControlled")
-    options.add_argument(
-        "--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    )
-    return uc.Chrome(options=options)
+logger = setup_logging()
 
 
 def fetch_news_content(url=BLOG_URL, max_clicks=20):
@@ -425,7 +320,7 @@ def parse_news_html(html_content):
         raise
 
 
-def generate_rss_feed(articles, feed_name="anthropic_news"):
+def generate_rss_feed(articles):
     """Generate RSS feed from news articles."""
     try:
         fg = FeedGenerator()
@@ -437,11 +332,7 @@ def generate_rss_feed(articles, feed_name="anthropic_news"):
         fg.author({"name": "Anthropic News"})
         fg.logo("https://www.anthropic.com/images/icons/apple-touch-icon.png")
         fg.subtitle("Latest updates from Anthropic's newsroom")
-        # Set links - self link first, then alternate (which becomes the main <link>)
-        fg.link(
-            href=f"https://www.anthropic.com/feeds/feed_{feed_name}.xml", rel="self"
-        )
-        fg.link(href="https://www.anthropic.com/news", rel="alternate")
+        setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
 
         # Sort articles for correct feed order (newest first in output)
         articles_sorted = sort_posts_for_feed(articles, date_field="date")
@@ -461,25 +352,6 @@ def generate_rss_feed(articles, feed_name="anthropic_news"):
 
     except Exception as e:
         logger.error(f"Error generating RSS feed: {str(e)}")
-        raise
-
-
-def save_rss_feed(feed_generator, feed_name="anthropic_news"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        # Ensure feeds directory exists and get its path
-        feeds_dir = ensure_feeds_directory()
-
-        # Create the output file path
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-
-        # Save the feed
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
         raise
 
 
@@ -509,8 +381,8 @@ def main(full_reset=False):
                    If False, do incremental update (click 2-3 times, merge with cache).
     """
     try:
-        cache = load_cache()
-        cached_articles = deserialize_articles(cache.get("articles", []))
+        cache = load_cache(FEED_NAME)
+        cached_articles = deserialize_entries(cache.get("entries", []))
 
         if full_reset or not cached_articles:
             mode = "full reset" if full_reset else "no cache exists"
@@ -522,20 +394,20 @@ def main(full_reset=False):
             html_content = fetch_news_content(max_clicks=2)
             new_articles = parse_news_html(html_content)
             logger.info(f"Found {len(new_articles)} articles from recent pages")
-            articles = merge_articles(new_articles, cached_articles)
+            articles = merge_entries(new_articles, cached_articles)
 
         if not articles:
             logger.warning("No articles found. Please check the HTML structure.")
             return False
 
         # Save to cache
-        save_cache(articles)
+        save_cache(FEED_NAME, articles)
 
         # Generate RSS feed with all articles
-        feed = generate_rss_feed(articles, FEED_NAME)
+        feed = generate_rss_feed(articles)
 
         # Save feed to file
-        output_file = save_rss_feed(feed, FEED_NAME)
+        save_rss_feed(feed, FEED_NAME)
 
         logger.info(f"Successfully generated RSS feed with {len(articles)} articles")
         return True

--- a/feed_generators/anthropic_red_blog.py
+++ b/feed_generators/anthropic_red_blog.py
@@ -1,50 +1,30 @@
-import requests
-from bs4 import BeautifulSoup
-from datetime import datetime, timedelta
-import pytz
-from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 import re
+from datetime import datetime
 
-from utils import sort_posts_for_feed
+import pytz
+from bs4 import BeautifulSoup
+from feedgen.feed import FeedGenerator
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+    stable_fallback_date,
 )
-logger = logging.getLogger(__name__)
+
+logger = setup_logging()
+
+FEED_NAME = "anthropic_red"
+BLOG_URL = "https://red.anthropic.com/"
 
 
-def stable_fallback_date(identifier):
-    """Generate a stable date from a URL or title hash."""
-    hash_val = abs(hash(identifier)) % 730
-    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
-    return epoch + timedelta(days=hash_val)
-
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def fetch_red_content(url="https://red.anthropic.com/"):
+def fetch_red_content(url=BLOG_URL):
     """Fetch content from Anthropic's red team blog."""
     try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
+        return fetch_page(url)
+    except Exception as e:
         logger.error(f"Error fetching red team blog content: {str(e)}")
         raise
 
@@ -72,13 +52,9 @@ def parse_date(date_text):
 def fetch_article_date(article_url):
     """Fetch the publication date from an individual article page."""
     try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(article_url, headers=headers, timeout=10)
-        response.raise_for_status()
+        html = fetch_page(article_url)
 
-        soup = BeautifulSoup(response.text, "html.parser")
+        soup = BeautifulSoup(html, "html.parser")
 
         # Look for date in d-article section
         article_section = soup.select_one("d-article")
@@ -197,7 +173,7 @@ def parse_red_html(html_content):
         raise
 
 
-def generate_rss_feed(articles, feed_name="anthropic_red"):
+def generate_rss_feed(articles, feed_name=FEED_NAME):
     """Generate RSS feed from red team blog articles."""
     try:
         fg = FeedGenerator()
@@ -205,7 +181,7 @@ def generate_rss_feed(articles, feed_name="anthropic_red"):
         fg.description(
             "Research from Anthropic's Frontier Red Team on what frontier AI models mean for national security"
         )
-        fg.link(href="https://red.anthropic.com/")
+        setup_feed_links(fg, BLOG_URL, feed_name)
         fg.language("en")
 
         # Set feed metadata
@@ -214,8 +190,6 @@ def generate_rss_feed(articles, feed_name="anthropic_red"):
         fg.subtitle(
             "Evidence-based analysis about AI's implications for cybersecurity, biosecurity, and autonomous systems"
         )
-        fg.link(href="https://red.anthropic.com/", rel="alternate")
-        fg.link(href=f"https://anthropic.com/feed_{feed_name}.xml", rel="self")
 
         # Sort articles for correct feed order (newest first in output)
         sorted_articles = sort_posts_for_feed(articles, date_field="date")
@@ -237,26 +211,7 @@ def generate_rss_feed(articles, feed_name="anthropic_red"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="anthropic_red"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        # Ensure feeds directory exists and get its path
-        feeds_dir = ensure_feeds_directory()
-
-        # Create the output file path
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-
-        # Save the feed
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(feed_name="anthropic_red"):
+def main(feed_name=FEED_NAME):
     """Main function to generate RSS feed from Anthropic's red team blog."""
     try:
         # Fetch blog content
@@ -273,7 +228,7 @@ def main(feed_name="anthropic_red"):
         feed = generate_rss_feed(articles, feed_name)
 
         # Save feed to file
-        output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, feed_name)
 
         logger.info(f"Successfully generated RSS feed with {len(articles)} articles")
         return True

--- a/feed_generators/anthropic_research_blog.py
+++ b/feed_generators/anthropic_research_blog.py
@@ -1,44 +1,28 @@
-import undetected_chromedriver as uc
-from bs4 import BeautifulSoup
-from datetime import datetime
-import pytz
-from feedgen.feed import FeedGenerator
 import time
-import logging
-from pathlib import Path
+from datetime import datetime
 
-from utils import sort_posts_for_feed
+import pytz
+from bs4 import BeautifulSoup
+from feedgen.feed import FeedGenerator
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+from utils import (
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    setup_selenium_driver,
+    sort_posts_for_feed,
+)
 
+logger = setup_logging()
 
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def setup_selenium_driver():
-    """Set up Selenium WebDriver with undetected-chromedriver."""
-    options = uc.ChromeOptions()
-    options.add_argument("--headless")  # Ensure headless mode is enabled
-    options.add_argument("--window-size=1920,1080")
-    options.add_argument("--disable-blink-features=AutomationControlled")
-    options.add_argument(
-        "--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    )
-    return uc.Chrome(options=options)
+FEED_NAME = "anthropic_research"
+BLOG_URL = "https://www.anthropic.com/research"
 
 
-def fetch_research_content_selenium(url="https://www.anthropic.com/research"):
+def fetch_research_content_selenium(url=BLOG_URL):
     """Fetch the fully loaded HTML content of the research page using Selenium."""
     driver = None
     try:
@@ -53,14 +37,10 @@ def fetch_research_content_selenium(url="https://www.anthropic.com/research"):
 
         # Wait for research articles to load by checking for specific elements
         try:
-            from selenium.webdriver.common.by import By
-            from selenium.webdriver.support.ui import WebDriverWait
-            from selenium.webdriver.support import expected_conditions as EC
-
             # Wait for research articles to be present
             WebDriverWait(driver, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, "a[href*='/research/']")))
             logger.info("Research articles loaded successfully")
-        except:
+        except Exception:
             logger.warning("Could not confirm articles loaded, proceeding anyway...")
 
         html_content = driver.page_source
@@ -240,21 +220,19 @@ def parse_research_html(html_content):
         raise
 
 
-def generate_rss_feed(articles, feed_name="anthropic_research"):
+def generate_rss_feed(articles):
     """Generate RSS feed from research articles."""
     try:
         fg = FeedGenerator()
         fg.title("Anthropic Research")
         fg.description("Latest research papers and updates from Anthropic")
-        fg.link(href="https://www.anthropic.com/research")
         fg.language("en")
 
         # Set feed metadata
         fg.author({"name": "Anthropic Research Team"})
         fg.logo("https://www.anthropic.com/images/icons/apple-touch-icon.png")
         fg.subtitle("Latest research from Anthropic")
-        fg.link(href="https://www.anthropic.com/research", rel="alternate")
-        fg.link(href=f"https://anthropic.com/research/feed_{feed_name}.xml", rel="self")
+        setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
 
         # Sort articles for correct feed order (newest first in output)
         # Articles without dates will appear at the end
@@ -282,26 +260,7 @@ def generate_rss_feed(articles, feed_name="anthropic_research"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="anthropic_research"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        # Ensure feeds directory exists and get its path
-        feeds_dir = ensure_feeds_directory()
-
-        # Create the output file path
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-
-        # Save the feed
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(feed_name="anthropic_research"):
+def main(full_reset=False):
     """Main function to generate RSS feed from Anthropic's research page."""
     try:
         # Fetch research content using Selenium
@@ -315,10 +274,10 @@ def main(feed_name="anthropic_research"):
             return False
 
         # Generate RSS feed
-        feed = generate_rss_feed(articles, feed_name)
+        feed = generate_rss_feed(articles)
 
         # Save feed to file
-        output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, FEED_NAME)
 
         logger.info(f"Successfully generated RSS feed with {len(articles)} articles")
         return True

--- a/feed_generators/blogsurgeai_feed_generator.py
+++ b/feed_generators/blogsurgeai_feed_generator.py
@@ -4,19 +4,25 @@ RSS Feed Generator for Surge AI Blog
 Scrapes https://www.surgehq.ai/blog and generates an RSS feed
 """
 
-import requests
-from bs4 import BeautifulSoup
-from feedgen.feed import FeedGenerator
-from datetime import datetime, timedelta
-from dateutil import parser
+from datetime import datetime
+
 import pytz
+from bs4 import BeautifulSoup
+from dateutil import parser
+from feedgen.feed import FeedGenerator
 
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    stable_fallback_date,
+)
 
-def stable_fallback_date(identifier):
-    """Generate a stable date from a URL or title hash."""
-    hash_val = abs(hash(identifier)) % 730
-    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
-    return epoch + timedelta(days=hash_val)
+logger = setup_logging()
+
+FEED_NAME = "blogsurgeai"
+BLOG_URL = "https://www.surgehq.ai/blog"
 
 
 def generate_blogsurgeai_feed():
@@ -24,39 +30,29 @@ def generate_blogsurgeai_feed():
 
     # Initialize feed generator
     fg = FeedGenerator()
-    fg.id("https://www.surgehq.ai/blog")
+    fg.id(BLOG_URL)
     fg.title("Surge AI Blog")
     fg.author({"name": "Surge AI", "email": "team@surgehq.ai"})
-    fg.link(href="https://www.surgehq.ai/blog", rel="alternate")
-    fg.link(
-        href="https://raw.githubusercontent.com/olshansky/rss-feeds/main/feeds/feed_blogsurgeai.xml",
-        rel="self",
-    )
+    setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
     fg.language("en")
     fg.description(
         "New methods, current trends & software infrastructure for NLP. Articles written by our senior engineering leads from Google, Facebook, Twitter, Harvard, MIT, and Y Combinator"
     )
 
     # Fetch the blog page
-    url = "https://www.surgehq.ai/blog"
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
-    }
-
     try:
-        response = requests.get(url, headers=headers, timeout=30)
-        response.raise_for_status()
+        html = fetch_page(BLOG_URL)
     except Exception as e:
-        print(f"Error fetching blog page: {e}")
+        logger.error(f"Error fetching blog page: {e}")
         return
 
     # Parse HTML
-    soup = BeautifulSoup(response.content, "html.parser")
+    soup = BeautifulSoup(html, "html.parser")
 
     # Find all blog post items
     blog_items = soup.find_all("div", class_="blog-hero-cms-item")
 
-    print(f"Found {len(blog_items)} blog posts")
+    logger.info(f"Found {len(blog_items)} blog posts")
 
     # Process each blog post
     for item in blog_items:
@@ -99,7 +95,7 @@ def generate_blogsurgeai_feed():
                                 pub_date = pytz.UTC.localize(pub_date)
                             break
                         except Exception as e:
-                            print(f"Could not parse date '{date_str}': {e}")
+                            logger.warning(f"Could not parse date '{date_str}': {e}")
 
             # Use stable fallback if no date was parsed
             if pub_date is None:
@@ -115,16 +111,14 @@ def generate_blogsurgeai_feed():
             # Set description
             fe.description(description)
 
-            print(f"Added: {title}")
+            logger.info(f"Added: {title}")
 
         except Exception as e:
-            print(f"Error processing blog item: {e}")
+            logger.error(f"Error processing blog item: {e}")
             continue
 
     # Generate RSS feed
-    output_path = "feeds/feed_blogsurgeai.xml"
-    fg.rss_file(output_path, pretty=True)
-    print(f"\nRSS feed generated successfully: {output_path}")
+    save_rss_feed(fg, FEED_NAME)
 
 
 if __name__ == "__main__":

--- a/feed_generators/chanderramesh_blog.py
+++ b/feed_generators/chanderramesh_blog.py
@@ -1,52 +1,22 @@
-import os
-import requests
-from bs4 import BeautifulSoup
-from datetime import datetime, timedelta
+from datetime import datetime
+
 import pytz
+from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 
-from utils import sort_posts_for_feed
-
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+    stable_fallback_date,
 )
-logger = logging.getLogger(__name__)
 
+logger = setup_logging()
 
-def stable_fallback_date(identifier):
-    """Generate a stable date from a URL or title hash."""
-    hash_val = abs(hash(identifier)) % 730
-    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
-    return epoch + timedelta(days=hash_val)
-
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def fetch_html_content(url):
-    """Fetch HTML content from the given URL."""
-    try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
-        logger.error(f"Error fetching content from {url}: {str(e)}")
-        raise
+FEED_NAME = "chanderramesh"
+BLOG_URL = "https://chanderramesh.com/writing"
 
 
 def parse_date(date_str):
@@ -102,14 +72,14 @@ def parse_writing_page(html_content, base_url="https://chanderramesh.com"):
                 "title": title,
                 "link": full_url,
                 "description": description,
-                "pub_date": pub_date,
+                "date": pub_date,
             }
 
             blog_posts.append(blog_post)
             logger.info(f"Parsed: {title} ({date_str})")
 
         # Sort for correct feed order (newest first in output)
-        blog_posts = sort_posts_for_feed(blog_posts, date_field="pub_date")
+        blog_posts = sort_posts_for_feed(blog_posts)
 
         logger.info(f"Successfully parsed {len(blog_posts)} blog posts")
         return blog_posts
@@ -119,7 +89,7 @@ def parse_writing_page(html_content, base_url="https://chanderramesh.com"):
         raise
 
 
-def generate_rss_feed(blog_posts, feed_name="chanderramesh"):
+def generate_rss_feed(blog_posts):
     """Generate RSS feed from blog posts."""
     try:
         fg = FeedGenerator()
@@ -127,14 +97,12 @@ def generate_rss_feed(blog_posts, feed_name="chanderramesh"):
         fg.description(
             "Essays by Chander Ramesh covering software, startups, investing, and philosophy"
         )
-        fg.link(href="https://chanderramesh.com/writing")
         fg.language("en")
 
         # Set feed metadata
         fg.author({"name": "Chander Ramesh"})
         fg.subtitle("Essays covering software, startups, investing, and philosophy")
-        fg.link(href="https://chanderramesh.com/writing", rel="alternate")
-        fg.link(href=f"https://chanderramesh.com/feed_{feed_name}.xml", rel="self")
+        setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
 
         # Add entries
         for post in blog_posts:
@@ -142,7 +110,7 @@ def generate_rss_feed(blog_posts, feed_name="chanderramesh"):
             fe.title(post["title"])
             fe.description(post["description"])
             fe.link(href=post["link"])
-            fe.published(post["pub_date"])
+            fe.published(post["date"])
             fe.id(post["link"])
 
         logger.info("Successfully generated RSS feed")
@@ -153,34 +121,20 @@ def generate_rss_feed(blog_posts, feed_name="chanderramesh"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="chanderramesh"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        feeds_dir = ensure_feeds_directory()
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(blog_url="https://chanderramesh.com/writing", feed_name="chanderramesh"):
+def main():
     """Main function to generate RSS feed from blog URL."""
     try:
         # Fetch blog content
-        html_content = fetch_html_content(blog_url)
+        html_content = fetch_page(BLOG_URL)
 
         # Parse blog posts
         blog_posts = parse_writing_page(html_content)
 
         # Generate RSS feed
-        feed = generate_rss_feed(blog_posts, feed_name)
+        feed = generate_rss_feed(blog_posts)
 
         # Save feed to file
-        _output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, FEED_NAME)
 
         return True
 

--- a/feed_generators/claude_blog.py
+++ b/feed_generators/claude_blog.py
@@ -3,24 +3,25 @@
 
 import argparse
 import html
-import json
-import logging
 import re
 from datetime import datetime
-from pathlib import Path
 
 import pytz
 import requests
 from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
 
-from utils import setup_feed_links, sort_posts_for_feed
-
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+from utils import (
+    load_cache,
+    merge_entries,
+    save_cache,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
 )
-logger = logging.getLogger(__name__)
+
+logger = setup_logging()
 
 BLOG_URL = "https://claude.com/blog"
 FEED_NAME = "claude"
@@ -30,30 +31,16 @@ DATE_PATTERN = re.compile(
     r"(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},\s+\d{4}"
 )
 
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def get_cache_file():
-    """Get the cache file path."""
-    return get_project_root() / "cache" / "claude_posts.json"
-
-
-def get_feeds_dir():
-    """Get the feeds directory path."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
+# Claude blog requires a custom header for Webflow/Finsweet
+CLAUDE_HEADERS = {
+    "X-Webflow-App-ID": "finsweet",
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+}
 
 
 def fetch_page(url):
     """Fetch a single page HTML with Finsweet header."""
-    headers = {
-        "X-Webflow-App-ID": "finsweet",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
-    }
+    headers = CLAUDE_HEADERS
     response = requests.get(url, headers=headers, timeout=30)
     response.raise_for_status()
     return response.text
@@ -146,7 +133,7 @@ def parse_posts(html_content):
             if description:
                 description = html.unescape(description)
             posts_by_url[full_url] = {
-                "url": full_url,
+                "link": full_url,
                 "title": title,
                 "date": date_obj.strftime("%Y-%m-%d") if date_obj else None,
                 "category": category,
@@ -154,49 +141,6 @@ def parse_posts(html_content):
             }
 
     return list(posts_by_url.values())
-
-
-def load_cache():
-    """Load existing cache or return empty structure."""
-    cache_file = get_cache_file()
-    if cache_file.exists():
-        with open(cache_file, "r") as f:
-            data = json.load(f)
-            logger.info(f"Loaded cache with {len(data.get('posts', []))} posts")
-            return data
-    logger.info("No cache file found, will do full fetch")
-    return {"last_updated": None, "posts": []}
-
-
-def save_cache(posts):
-    """Save posts to cache file."""
-    cache_file = get_cache_file()
-    cache_file.parent.mkdir(exist_ok=True)
-    data = {
-        "last_updated": datetime.now(pytz.UTC).isoformat(),
-        "posts": posts,
-    }
-    with open(cache_file, "w") as f:
-        json.dump(data, f, indent=2)
-    logger.info(f"Saved cache with {len(posts)} posts to {cache_file}")
-
-
-def merge_posts(new_posts, cached_posts):
-    """Merge new posts into cache, dedupe by URL, sort by date desc."""
-    existing_urls = {p["url"] for p in cached_posts}
-    merged = list(cached_posts)
-
-    added_count = 0
-    for post in new_posts:
-        if post["url"] not in existing_urls:
-            merged.append(post)
-            existing_urls.add(post["url"])
-            added_count += 1
-
-    logger.info(f"Added {added_count} new posts to cache")
-
-    # Sort for correct feed order (newest first in output)
-    return sort_posts_for_feed(merged, date_field="date")
 
 
 def fetch_all_pages():
@@ -207,7 +151,7 @@ def fetch_all_pages():
     logger.info(f"Found {len(all_posts)} posts on main page")
 
     # Get unique post URLs to track duplicates
-    seen_urls = {p["url"] for p in all_posts}
+    seen_urls = {p["link"] for p in all_posts}
 
     # Extract pagination collection IDs
     collection_ids = extract_pagination_ids(html_content)
@@ -228,7 +172,7 @@ def fetch_all_pages():
                 break
 
             page_posts = parse_posts(page_html)
-            new_posts = [p for p in page_posts if p["url"] not in seen_urls]
+            new_posts = [p for p in page_posts if p["link"] not in seen_urls]
 
             if not new_posts:
                 consecutive_empty += 1
@@ -237,7 +181,7 @@ def fetch_all_pages():
                 consecutive_empty = 0
                 logger.info(f"  Found {len(new_posts)} new posts")
                 all_posts.extend(new_posts)
-                seen_urls.update(p["url"] for p in new_posts)
+                seen_urls.update(p["link"] for p in new_posts)
 
             page += 1
 
@@ -270,8 +214,8 @@ def generate_rss_feed(posts):
         fe = fg.add_entry()
         fe.title(post["title"])
         fe.description(post["description"])
-        fe.link(href=post["url"])
-        fe.id(post["url"])
+        fe.link(href=post["link"])
+        fe.id(post["link"])
 
         if post.get("category"):
             fe.category(term=post["category"])
@@ -287,15 +231,6 @@ def generate_rss_feed(posts):
     return fg
 
 
-def save_rss_feed(feed_generator):
-    """Save the RSS feed to a file in the feeds directory."""
-    feeds_dir = get_feeds_dir()
-    output_file = feeds_dir / f"feed_{FEED_NAME}.xml"
-    feed_generator.rss_file(str(output_file), pretty=True)
-    logger.info(f"Saved RSS feed to {output_file}")
-    return output_file
-
-
 def main(full_reset=False):
     """Main function to generate RSS feed from blog URL.
 
@@ -303,9 +238,9 @@ def main(full_reset=False):
         full_reset: If True, fetch all pages. If False, only fetch page 1
                    and merge with cached posts.
     """
-    cache = load_cache()
+    cache = load_cache(FEED_NAME)
 
-    if full_reset or not cache["posts"]:
+    if full_reset or not cache.get("entries", []):
         mode = "full reset" if full_reset else "no cache exists"
         logger.info(f"Running full fetch ({mode})")
         posts = fetch_all_pages()
@@ -314,11 +249,11 @@ def main(full_reset=False):
         html_content = fetch_page(BLOG_URL)
         new_posts = parse_posts(html_content)
         logger.info(f"Found {len(new_posts)} posts on page 1")
-        posts = merge_posts(new_posts, cache["posts"])
+        posts = merge_entries(new_posts, cache["entries"])
 
-    save_cache(posts)
+    save_cache(FEED_NAME, posts)
     feed = generate_rss_feed(posts)
-    save_rss_feed(feed)
+    save_rss_feed(feed, FEED_NAME)
 
     logger.info("Done!")
     return True

--- a/feed_generators/cursor_blog.py
+++ b/feed_generators/cursor_blog.py
@@ -1,39 +1,26 @@
 import argparse
-import json
-import logging
 import re
 from datetime import datetime
-from pathlib import Path
 
 import pytz
 import requests
 from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
 
-from utils import setup_feed_links, sort_posts_for_feed
+from utils import (
+    load_cache,
+    merge_entries,
+    save_cache,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+)
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+logger = setup_logging()
 
 BLOG_URL = "https://cursor.com/blog"
 FEED_NAME = "cursor"
-
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def get_cache_file():
-    """Get the cache file path."""
-    return get_project_root() / "cache" / "cursor_posts.json"
-
-
-def get_feeds_dir():
-    """Get the feeds directory path."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
 
 
 def fetch_page(url):
@@ -71,7 +58,7 @@ def parse_posts(html):
         category = category_el.get_text(strip=True).rstrip(" ·") if category_el else ""
 
         posts.append({
-            "url": href,
+            "link": href,
             "title": title,
             "description": description,
             "date": date,
@@ -98,49 +85,6 @@ def parse_posts(html):
     return posts, next_url
 
 
-def load_cache():
-    """Load existing cache or return empty structure."""
-    cache_file = get_cache_file()
-    if cache_file.exists():
-        with open(cache_file, "r") as f:
-            data = json.load(f)
-            logger.info(f"Loaded cache with {len(data.get('posts', []))} posts")
-            return data
-    logger.info("No cache file found, will do full fetch")
-    return {"last_updated": None, "posts": []}
-
-
-def save_cache(posts):
-    """Save posts to cache file."""
-    cache_file = get_cache_file()
-    cache_file.parent.mkdir(exist_ok=True)
-    data = {
-        "last_updated": datetime.now(pytz.UTC).isoformat(),
-        "posts": posts,
-    }
-    with open(cache_file, "w") as f:
-        json.dump(data, f, indent=2)
-    logger.info(f"Saved cache with {len(posts)} posts to {cache_file}")
-
-
-def merge_posts(new_posts, cached_posts):
-    """Merge new posts into cache, dedupe by URL, sort by date desc."""
-    existing_urls = {p["url"] for p in cached_posts}
-    merged = list(cached_posts)
-
-    added_count = 0
-    for post in new_posts:
-        if post["url"] not in existing_urls:
-            merged.append(post)
-            existing_urls.add(post["url"])
-            added_count += 1
-
-    logger.info(f"Added {added_count} new posts to cache")
-
-    # Sort for correct feed order (newest first in output)
-    return sort_posts_for_feed(merged, date_field="date")
-
-
 def fetch_all_pages():
     """Follow pagination until no Next link. Returns all posts."""
     all_posts = []
@@ -161,9 +105,9 @@ def fetch_all_pages():
     seen = set()
     unique_posts = []
     for post in all_posts:
-        if post["url"] not in seen:
+        if post["link"] not in seen:
             unique_posts.append(post)
-            seen.add(post["url"])
+            seen.add(post["link"])
 
     # Sort for correct feed order (newest first in output)
     sorted_posts = sort_posts_for_feed(unique_posts, date_field="date")
@@ -186,8 +130,8 @@ def generate_rss_feed(posts):
         fe = fg.add_entry()
         fe.title(post["title"])
         fe.description(post["description"])
-        fe.link(href=post["url"])
-        fe.id(post["url"])
+        fe.link(href=post["link"])
+        fe.id(post["link"])
 
         if post.get("date"):
             try:
@@ -203,20 +147,11 @@ def generate_rss_feed(posts):
     return fg
 
 
-def save_rss_feed(feed_generator):
-    """Save the RSS feed to a file."""
-    feeds_dir = get_feeds_dir()
-    output_file = feeds_dir / f"feed_{FEED_NAME}.xml"
-    feed_generator.rss_file(str(output_file), pretty=True)
-    logger.info(f"Saved RSS feed to {output_file}")
-    return output_file
-
-
 def main(full_reset=False):
     """Main function to generate RSS feed."""
-    cache = load_cache()
+    cache = load_cache(FEED_NAME)
 
-    if full_reset or not cache["posts"]:
+    if full_reset or not cache.get("entries", []):
         mode = "full reset" if full_reset else "no cache exists"
         logger.info(f"Running full fetch ({mode})")
         posts = fetch_all_pages()
@@ -225,11 +160,11 @@ def main(full_reset=False):
         html = fetch_page(BLOG_URL)
         new_posts, _ = parse_posts(html)
         logger.info(f"Found {len(new_posts)} posts on page 1")
-        posts = merge_posts(new_posts, cache["posts"])
+        posts = merge_entries(new_posts, cache["entries"])
 
-    save_cache(posts)
+    save_cache(FEED_NAME, posts)
     feed = generate_rss_feed(posts)
-    save_rss_feed(feed)
+    save_rss_feed(feed, FEED_NAME)
 
     logger.info("Done!")
     return True

--- a/feed_generators/cursor_blog.py
+++ b/feed_generators/cursor_blog.py
@@ -3,11 +3,11 @@ import re
 from datetime import datetime
 
 import pytz
-import requests
 from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
 
 from utils import (
+    fetch_page,
     load_cache,
     merge_entries,
     save_cache,
@@ -22,15 +22,6 @@ logger = setup_logging()
 BLOG_URL = "https://cursor.com/blog"
 FEED_NAME = "cursor"
 
-
-def fetch_page(url):
-    """Fetch a single page HTML."""
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    }
-    response = requests.get(url, headers=headers, timeout=30)
-    response.raise_for_status()
-    return response.text
 
 
 def parse_posts(html):

--- a/feed_generators/dagster_blog.py
+++ b/feed_generators/dagster_blog.py
@@ -1,43 +1,27 @@
 import argparse
-import json
-import logging
 from datetime import datetime
-from pathlib import Path
 
 import pytz
 import requests
 from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
 
-from utils import setup_feed_links, sort_posts_for_feed
-
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+from utils import (
+    load_cache,
+    merge_entries,
+    save_cache,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
 )
-logger = logging.getLogger(__name__)
+
+logger = setup_logging()
 
 BLOG_URL = "https://dagster.io/blog"
 FEED_NAME = "dagster"
 # Dagster uses Webflow CMS pagination with this query param
 PAGINATION_PARAM = "a17fdf47_page"
-
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def get_cache_file():
-    """Get the cache file path."""
-    return get_project_root() / "cache" / "dagster_posts.json"
-
-
-def get_feeds_dir():
-    """Get the feeds directory path."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
 
 
 def fetch_page(url):
@@ -79,7 +63,7 @@ def parse_posts(html_content):
             if link:
                 blog_posts.append(
                     {
-                        "url": link,
+                        "link": link,
                         "title": title,
                         "date": date_obj.strftime("%Y-%m-%d"),
                         "description": description,
@@ -114,7 +98,7 @@ def parse_posts(html_content):
 
         blog_posts.append(
             {
-                "url": link,
+                "link": link,
                 "title": title,
                 "date": date_obj.strftime("%Y-%m-%d"),
                 "description": description,
@@ -126,49 +110,6 @@ def parse_posts(html_content):
     has_next_page = next_link is not None and next_link.get("href")
 
     return blog_posts, has_next_page
-
-
-def load_cache():
-    """Load existing cache or return empty structure."""
-    cache_file = get_cache_file()
-    if cache_file.exists():
-        with open(cache_file, "r") as f:
-            data = json.load(f)
-            logger.info(f"Loaded cache with {len(data.get('posts', []))} posts")
-            return data
-    logger.info("No cache file found, will do full fetch")
-    return {"last_updated": None, "posts": []}
-
-
-def save_cache(posts):
-    """Save posts to cache file."""
-    cache_file = get_cache_file()
-    cache_file.parent.mkdir(exist_ok=True)
-    data = {
-        "last_updated": datetime.now(pytz.UTC).isoformat(),
-        "posts": posts,
-    }
-    with open(cache_file, "w") as f:
-        json.dump(data, f, indent=2)
-    logger.info(f"Saved cache with {len(posts)} posts to {cache_file}")
-
-
-def merge_posts(new_posts, cached_posts):
-    """Merge new posts into cache, dedupe by URL, sort by date desc."""
-    existing_urls = {p["url"] for p in cached_posts}
-    merged = list(cached_posts)
-
-    added_count = 0
-    for post in new_posts:
-        if post["url"] not in existing_urls:
-            merged.append(post)
-            existing_urls.add(post["url"])
-            added_count += 1
-
-    logger.info(f"Added {added_count} new posts to cache")
-
-    # Sort for correct feed order (newest first in output)
-    return sort_posts_for_feed(merged, date_field="date")
 
 
 def fetch_all_pages():
@@ -196,9 +137,9 @@ def fetch_all_pages():
     seen = set()
     unique_posts = []
     for post in all_posts:
-        if post["url"] not in seen:
+        if post["link"] not in seen:
             unique_posts.append(post)
-            seen.add(post["url"])
+            seen.add(post["link"])
 
     # Sort for correct feed order (newest first in output)
     sorted_posts = sort_posts_for_feed(unique_posts, date_field="date")
@@ -223,8 +164,8 @@ def generate_rss_feed(posts):
         fe = fg.add_entry()
         fe.title(post["title"])
         fe.description(post["description"])
-        fe.link(href=post["url"])
-        fe.id(post["url"])
+        fe.link(href=post["link"])
+        fe.id(post["link"])
 
         if post.get("date"):
             try:
@@ -237,15 +178,6 @@ def generate_rss_feed(posts):
     return fg
 
 
-def save_rss_feed(feed_generator):
-    """Save the RSS feed to a file in the feeds directory."""
-    feeds_dir = get_feeds_dir()
-    output_file = feeds_dir / f"feed_{FEED_NAME}.xml"
-    feed_generator.rss_file(str(output_file), pretty=True)
-    logger.info(f"Saved RSS feed to {output_file}")
-    return output_file
-
-
 def main(full_reset=False):
     """Main function to generate RSS feed from blog URL.
 
@@ -253,9 +185,9 @@ def main(full_reset=False):
         full_reset: If True, fetch all pages. If False, only fetch page 1
                    and merge with cached posts.
     """
-    cache = load_cache()
+    cache = load_cache(FEED_NAME)
 
-    if full_reset or not cache["posts"]:
+    if full_reset or not cache.get("entries", []):
         mode = "full reset" if full_reset else "no cache exists"
         logger.info(f"Running full fetch ({mode})")
         posts = fetch_all_pages()
@@ -264,11 +196,11 @@ def main(full_reset=False):
         html = fetch_page(BLOG_URL)
         new_posts, _ = parse_posts(html)
         logger.info(f"Found {len(new_posts)} posts on page 1")
-        posts = merge_posts(new_posts, cache["posts"])
+        posts = merge_entries(new_posts, cache["entries"])
 
-    save_cache(posts)
+    save_cache(FEED_NAME, posts)
     feed = generate_rss_feed(posts)
-    save_rss_feed(feed)
+    save_rss_feed(feed, FEED_NAME)
 
     logger.info("Done!")
     return True

--- a/feed_generators/dagster_blog.py
+++ b/feed_generators/dagster_blog.py
@@ -2,11 +2,11 @@ import argparse
 from datetime import datetime
 
 import pytz
-import requests
 from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
 
 from utils import (
+    fetch_page,
     load_cache,
     merge_entries,
     save_cache,
@@ -23,15 +23,6 @@ FEED_NAME = "dagster"
 # Dagster uses Webflow CMS pagination with this query param
 PAGINATION_PARAM = "a17fdf47_page"
 
-
-def fetch_page(url):
-    """Fetch a single page HTML."""
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    }
-    response = requests.get(url, headers=headers, timeout=30)
-    response.raise_for_status()
-    return response.text
 
 
 def parse_posts(html_content):

--- a/feed_generators/deeplearningai_the_batch.py
+++ b/feed_generators/deeplearningai_the_batch.py
@@ -1,103 +1,28 @@
 import argparse
-import json
-import logging
 import re
-from datetime import datetime, timedelta
-from pathlib import Path
 
-import pytz
 import requests
 from bs4 import BeautifulSoup
 from dateutil import parser as date_parser
 from feedgen.feed import FeedGenerator
-from utils import (get_cache_dir, get_feeds_dir, setup_feed_links,
-                   sort_posts_for_feed)
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+from utils import (
+    deserialize_entries,
+    load_cache,
+    merge_entries,
+    save_cache,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+    stable_fallback_date,
 )
-logger = logging.getLogger(__name__)
+
+logger = setup_logging()
 
 FEED_NAME = "the_batch"
 BLOG_URL = "https://www.deeplearning.ai/the-batch/"
 MAX_PAGES = 30  # Safety limit for pagination
-
-
-def stable_fallback_date(identifier):
-    """Generate a stable date from a URL or title hash."""
-    hash_val = abs(hash(identifier)) % 730  # ~2 years of days
-    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
-    return epoch + timedelta(days=hash_val)
-
-
-def get_cache_file():
-    """Get the cache file path."""
-    return get_cache_dir() / f"{FEED_NAME}_posts.json"
-
-
-def load_cache():
-    """Load existing cache or return empty structure."""
-    cache_file = get_cache_file()
-    if cache_file.exists():
-        with open(cache_file, "r") as f:
-            data = json.load(f)
-            logger.info(f"Loaded cache with {len(data.get('articles', []))} articles")
-            return data
-    logger.info("No cache file found, will do full fetch")
-    return {"last_updated": None, "articles": []}
-
-
-def save_cache(articles):
-    """Save articles to cache file."""
-    cache_file = get_cache_file()
-    serializable_articles = []
-    for article in articles:
-        article_copy = article.copy()
-        if isinstance(article_copy.get("published"), datetime):
-            article_copy["published"] = article_copy["published"].isoformat()
-        serializable_articles.append(article_copy)
-
-    data = {
-        "last_updated": datetime.now(pytz.UTC).isoformat(),
-        "articles": serializable_articles,
-    }
-    with open(cache_file, "w") as f:
-        json.dump(data, f, indent=2)
-    logger.info(f"Saved cache with {len(articles)} articles to {cache_file}")
-
-
-def deserialize_articles(articles):
-    """Convert cached articles back to proper format with datetime objects."""
-    result = []
-    for article in articles:
-        article_copy = article.copy()
-        if isinstance(article_copy.get("published"), str):
-            try:
-                article_copy["published"] = datetime.fromisoformat(
-                    article_copy["published"]
-                )
-            except ValueError:
-                article_copy["published"] = stable_fallback_date(
-                    article_copy.get("link", "")
-                )
-        result.append(article_copy)
-    return result
-
-
-def merge_articles(new_articles, cached_articles):
-    """Merge new articles into cache, dedupe by link, sort by date desc."""
-    existing_links = {a["link"] for a in cached_articles}
-    merged = list(cached_articles)
-
-    added_count = 0
-    for article in new_articles:
-        if article["link"] not in existing_links:
-            merged.append(article)
-            existing_links.add(article["link"])
-            added_count += 1
-
-    logger.info(f"Added {added_count} new articles to cache")
-    return sort_posts_for_feed(merged, date_field="published")
 
 
 def fetch_page(url: str) -> str:
@@ -111,13 +36,14 @@ def fetch_page(url: str) -> str:
     return response.text
 
 
-def parse_date(value: str | None, fallback_id: str = "") -> datetime:
+def parse_date(value: str | None, fallback_id: str = ""):
     """Parse date text/datetime strings into timezone-aware datetime."""
     if not value:
         return stable_fallback_date(fallback_id)
     try:
         dt = date_parser.parse(value)
         if dt.tzinfo is None:
+            import pytz
             dt = dt.replace(tzinfo=pytz.UTC)
         return dt
     except (ValueError, TypeError) as exc:
@@ -285,7 +211,7 @@ def parse_articles_from_html(html_content: str) -> list[dict]:
             parent = anchor.parent
             if parent:
                 date_text = extract_date_text(parent)
-        published = parse_date(date_text, fallback_id=link)
+        date = parse_date(date_text, fallback_id=link)
 
         # Extract description from nearby paragraph or use title
         description = extract_description(anchor) or title
@@ -294,7 +220,7 @@ def parse_articles_from_html(html_content: str) -> list[dict]:
             {
                 "title": title,
                 "link": link,
-                "published": published,
+                "date": date,
                 "description": description,
             }
         )
@@ -369,24 +295,17 @@ def build_feed(articles: list[dict]) -> FeedGenerator:
     setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
 
     # Sort articles for correct feed order (newest first in output)
-    articles_sorted = sort_posts_for_feed(articles, date_field="published")
+    articles_sorted = sort_posts_for_feed(articles, date_field="date")
 
     for article in articles_sorted:
         entry = fg.add_entry()
         entry.title(article["title"])
         entry.link(href=article["link"])
         entry.id(article["link"])
-        entry.published(article["published"])
+        entry.published(article["date"])
         entry.description(article["description"])
 
     return fg
-
-
-def save_feed(feed: FeedGenerator) -> Path:
-    output_path = get_feeds_dir() / f"feed_{FEED_NAME}.xml"
-    feed.rss_file(str(output_path), pretty=True)
-    logger.info("Wrote feed to %s", output_path)
-    return output_path
 
 
 def main(full_reset=False):
@@ -395,8 +314,8 @@ def main(full_reset=False):
     Args:
         full_reset: If True, fetch all pages. If False, fetch only first 3 pages and merge with cache.
     """
-    cache = load_cache()
-    cached_articles = deserialize_articles(cache.get("articles", []))
+    cache = load_cache(FEED_NAME)
+    cached_articles = deserialize_entries(cache.get("entries", []))
 
     if full_reset or not cached_articles:
         mode = "full reset" if full_reset else "no cache exists"
@@ -406,17 +325,17 @@ def main(full_reset=False):
         logger.info("Running incremental update (3 pages only)")
         new_articles = fetch_all_articles(max_pages=3)
         logger.info(f"Found {len(new_articles)} articles from recent pages")
-        articles = merge_articles(new_articles, cached_articles)
+        articles = merge_entries(new_articles, cached_articles)
 
     if not articles:
         logger.warning("No articles found")
         return False
 
     # Save to cache
-    save_cache(articles)
+    save_cache(FEED_NAME, articles)
 
     feed = build_feed(articles)
-    save_feed(feed)
+    save_rss_feed(feed, FEED_NAME)
     logger.info(f"Successfully generated RSS feed with {len(articles)} articles")
     return True
 

--- a/feed_generators/deeplearningai_the_batch.py
+++ b/feed_generators/deeplearningai_the_batch.py
@@ -1,6 +1,7 @@
 import argparse
 import re
 
+import pytz
 import requests
 from bs4 import BeautifulSoup
 from dateutil import parser as date_parser
@@ -34,7 +35,6 @@ def parse_date(value: str | None, fallback_id: str = ""):
     try:
         dt = date_parser.parse(value)
         if dt.tzinfo is None:
-            import pytz
             dt = dt.replace(tzinfo=pytz.UTC)
         return dt
     except (ValueError, TypeError) as exc:

--- a/feed_generators/deeplearningai_the_batch.py
+++ b/feed_generators/deeplearningai_the_batch.py
@@ -8,6 +8,7 @@ from feedgen.feed import FeedGenerator
 
 from utils import (
     deserialize_entries,
+    fetch_page,
     load_cache,
     merge_entries,
     save_cache,
@@ -24,16 +25,6 @@ FEED_NAME = "the_batch"
 BLOG_URL = "https://www.deeplearning.ai/the-batch/"
 MAX_PAGES = 30  # Safety limit for pagination
 
-
-def fetch_page(url: str) -> str:
-    """Fetch a page using requests."""
-    logger.info(f"Fetching: {url}")
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    }
-    response = requests.get(url, headers=headers, timeout=30)
-    response.raise_for_status()
-    return response.text
 
 
 def parse_date(value: str | None, fallback_id: str = ""):

--- a/feed_generators/google_ai_blog.py
+++ b/feed_generators/google_ai_blog.py
@@ -1,13 +1,16 @@
-import logging
 from datetime import datetime
-from pathlib import Path
 
 import pytz
-import requests
 from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
 
-from utils import setup_feed_links, sort_posts_for_feed
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+)
 
 # TODO_IMPROVE: Add caching (Pattern 2) and "Load More" pagination support.
 # Currently only fetches the first page of results. Should:
@@ -16,38 +19,19 @@ from utils import setup_feed_links, sort_posts_for_feed
 # 3. Support --full flag for full reset vs incremental updates
 # See cursor_blog.py or dagster_blog.py for reference implementation.
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
-logger = logging.getLogger(__name__)
+logger = setup_logging()
+
+FEED_NAME = "google_ai"
+BLOG_URL = "https://developers.googleblog.com/search/?technology_categories=AI"
 
 
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def fetch_blog_content(
-    url="https://developers.googleblog.com/search/?technology_categories=AI",
-):
+def fetch_blog_content(url=BLOG_URL):
     """Fetch the HTML content of the Google Developers Blog AI page."""
     try:
         logger.info(f"Fetching content from URL: {url}")
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=30)
-        response.raise_for_status()
+        html = fetch_page(url)
         logger.info("Content fetched successfully")
-        return response.text
+        return html
     except Exception as e:
         logger.error(f"Error fetching content: {e}")
         raise
@@ -145,16 +129,12 @@ def parse_blog_posts(html_content):
     return posts
 
 
-def create_rss_feed(posts, output_file):
+def create_rss_feed(posts):
     """Create an RSS feed from the blog posts."""
     fg = FeedGenerator()
     fg.title("Google Developers Blog - AI")
     fg.description("Latest AI-related posts from Google Developers Blog")
-    setup_feed_links(
-        fg,
-        "https://developers.googleblog.com/search/?technology_categories=AI",
-        "google_ai",
-    )
+    setup_feed_links(fg, BLOG_URL, FEED_NAME)
     fg.language("en")
 
     # Sort posts for correct feed output (oldest first, feedgen reverses it)
@@ -183,9 +163,7 @@ def create_rss_feed(posts, output_file):
         if post.get("category"):
             fe.category(term=post["category"])
 
-    # Write the feed to file
-    fg.rss_file(output_file, pretty=True)
-    logger.info(f"RSS feed written to {output_file}")
+    return fg
 
 
 def main():
@@ -201,10 +179,9 @@ def main():
             logger.warning("No posts found to add to the feed")
             return
 
-        # Create RSS feed
-        feeds_dir = ensure_feeds_directory()
-        output_file = feeds_dir / "feed_google_ai.xml"
-        create_rss_feed(posts, str(output_file))
+        # Create and save RSS feed
+        fg = create_rss_feed(posts)
+        save_rss_feed(fg, FEED_NAME)
 
         logger.info("RSS feed generation completed successfully!")
 

--- a/feed_generators/hamel_blog.py
+++ b/feed_generators/hamel_blog.py
@@ -1,49 +1,21 @@
-import requests
-from bs4 import BeautifulSoup
-from datetime import datetime, timedelta
+from datetime import datetime
+
 import pytz
+from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    stable_fallback_date,
 )
-logger = logging.getLogger(__name__)
 
+logger = setup_logging()
 
-def stable_fallback_date(identifier):
-    """Generate a stable date from a URL or title hash."""
-    hash_val = abs(hash(identifier)) % 730
-    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
-    return epoch + timedelta(days=hash_val)
-
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def fetch_html_content(url):
-    """Fetch HTML content from the given URL."""
-    try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
-        logger.error(f"Error fetching content from {url}: {str(e)}")
-        raise
+FEED_NAME = "hamel"
+BLOG_URL = "https://hamel.dev/"
 
 
 def parse_blog_page(html_content, base_url="https://hamel.dev"):
@@ -101,7 +73,7 @@ def parse_blog_page(html_content, base_url="https://hamel.dev"):
                     "title": title,
                     "link": full_url,
                     "description": title,  # Use title as description since we don't fetch article content
-                    "pub_date": pub_date,
+                    "date": pub_date,
                 }
 
                 blog_posts.append(blog_post)
@@ -119,7 +91,7 @@ def parse_blog_page(html_content, base_url="https://hamel.dev"):
         raise
 
 
-def generate_rss_feed(blog_posts, feed_name="hamel"):
+def generate_rss_feed(blog_posts):
     """Generate RSS feed from blog posts."""
     try:
         fg = FeedGenerator()
@@ -127,17 +99,12 @@ def generate_rss_feed(blog_posts, feed_name="hamel"):
         fg.description(
             "Notes on applied AI engineering, machine learning, and data science."
         )
-        fg.link(href="https://hamel.dev/")
         fg.language("en")
 
         # Set feed metadata
         fg.author({"name": "Hamel Husain"})
         fg.subtitle("Applied AI engineering, machine learning, and data science")
-        fg.link(href="https://hamel.dev/", rel="alternate")
-        fg.link(
-            href=f"https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_{feed_name}.xml",
-            rel="self",
-        )
+        setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
 
         # Add entries
         for post in blog_posts:
@@ -145,7 +112,7 @@ def generate_rss_feed(blog_posts, feed_name="hamel"):
             fe.title(post["title"])
             fe.description(post["description"])
             fe.link(href=post["link"])
-            fe.published(post["pub_date"])
+            fe.published(post["date"])
             fe.id(post["link"])
 
         logger.info("Successfully generated RSS feed")
@@ -156,34 +123,20 @@ def generate_rss_feed(blog_posts, feed_name="hamel"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="hamel"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        feeds_dir = ensure_feeds_directory()
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(blog_url="https://hamel.dev/", feed_name="hamel"):
+def main():
     """Main function to generate RSS feed from blog URL."""
     try:
         # Fetch blog content
-        html_content = fetch_html_content(blog_url)
+        html_content = fetch_page(BLOG_URL)
 
         # Parse blog posts
         blog_posts = parse_blog_page(html_content)
 
         # Generate RSS feed
-        feed = generate_rss_feed(blog_posts, feed_name)
+        feed = generate_rss_feed(blog_posts)
 
         # Save feed to file
-        _output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, FEED_NAME)
 
         return True
 

--- a/feed_generators/ollama_blog.py
+++ b/feed_generators/ollama_blog.py
@@ -1,40 +1,27 @@
-import requests
-from bs4 import BeautifulSoup
 from datetime import datetime
+
 import pytz
+from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+)
 
+logger = setup_logging()
 
-def get_project_root():
-    """Get the project root directory."""
-    # Since this script is in feed_generators/ollama_blog.py,
-    # we need to go up one level to reach the project root
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
+FEED_NAME = "ollama"
+BLOG_URL = "https://ollama.com/blog"
 
 
-def fetch_blog_content(url):
+def fetch_blog_content(url=BLOG_URL):
     """Fetch blog content from the given URL."""
     try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
+        return fetch_page(url)
+    except Exception as e:
         logger.error(f"Error fetching blog content: {str(e)}")
         raise
 
@@ -72,21 +59,19 @@ def parse_blog_html(html_content):
         raise
 
 
-def generate_rss_feed(blog_posts, feed_name="ollama"):
+def generate_rss_feed(blog_posts, feed_name=FEED_NAME):
     """Generate RSS feed from blog posts."""
     try:
         fg = FeedGenerator()
         fg.title("Ollama Blog")
         fg.description("Get up and running with large language models.")
-        fg.link(href="https://ollama.com/blog")
+        setup_feed_links(fg, BLOG_URL, feed_name)
         fg.language("en")
 
         # Set feed metadata
         fg.author({"name": "Ollama"})
         fg.logo("https://ollama.com/public/icon-64x64.png")
         fg.subtitle("Latest updates from Ollama")
-        fg.link(href="https://ollama.com/blog", rel="alternate")
-        fg.link(href=f"https://ollama.com/blog/feed_{feed_name}.xml", rel="self")
 
         # Add entries
         for post in blog_posts:
@@ -105,26 +90,7 @@ def generate_rss_feed(blog_posts, feed_name="ollama"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="ollama"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        # Ensure feeds directory exists and get its path
-        feeds_dir = ensure_feeds_directory()
-
-        # Create the output file path
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-
-        # Save the feed
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(blog_url="https://ollama.com/blog", feed_name="ollama"):
+def main(blog_url=BLOG_URL, feed_name=FEED_NAME):
     """Main function to generate RSS feed from blog URL."""
     try:
         # Fetch blog content
@@ -137,7 +103,7 @@ def main(blog_url="https://ollama.com/blog", feed_name="ollama"):
         feed = generate_rss_feed(blog_posts, feed_name)
 
         # Save feed to file
-        output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, feed_name)
 
         return True
 

--- a/feed_generators/openai_research_blog.py
+++ b/feed_generators/openai_research_blog.py
@@ -1,36 +1,23 @@
-import undetected_chromedriver as uc
-from bs4 import BeautifulSoup
-from datetime import datetime, timedelta
-import pytz
-from feedgen.feed import FeedGenerator
 import time
-import logging
-from pathlib import Path
+from datetime import datetime
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+import pytz
+from bs4 import BeautifulSoup
+from feedgen.feed import FeedGenerator
+
+from utils import (
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    setup_selenium_driver,
+    sort_posts_for_feed,
+    stable_fallback_date,
 )
-logger = logging.getLogger(__name__)
 
+logger = setup_logging()
 
-def stable_fallback_date(identifier):
-    """Generate a stable date from a URL or title hash."""
-    hash_val = abs(hash(identifier)) % 730
-    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
-    return epoch + timedelta(days=hash_val)
-
-
-def setup_selenium_driver():
-    """Set up Selenium WebDriver with undetected-chromedriver."""
-    options = uc.ChromeOptions()
-    options.add_argument("--headless")  # Ensure headless mode is enabled
-    options.add_argument("--window-size=1920,1080")
-    options.add_argument("--disable-blink-features=AutomationControlled")
-    options.add_argument(
-        "--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    )
-    return uc.Chrome(options=options)
+FEED_NAME = "openai_research"
+BLOG_URL = "https://openai.com/news/research"
 
 
 def fetch_news_content_selenium(url):
@@ -106,15 +93,18 @@ def parse_openai_news_html(html_content):
     return articles
 
 
-def generate_rss_feed(articles, feed_name="openai_research"):
+def generate_rss_feed(articles):
     """Generate RSS feed from parsed articles."""
     fg = FeedGenerator()
     fg.title("OpenAI Research News")
     fg.description("Latest research news and updates from OpenAI")
-    fg.link(href="https://openai.com/news/research")
     fg.language("en")
+    setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
 
-    for article in articles:
+    # Sort articles for correct feed order (newest first in output)
+    articles_sorted = sort_posts_for_feed(articles, date_field="date")
+
+    for article in articles_sorted:
         fe = fg.add_entry()
         fe.title(article["title"])
         fe.link(href=article["link"])
@@ -126,17 +116,7 @@ def generate_rss_feed(articles, feed_name="openai_research"):
     return fg
 
 
-def save_rss_feed(feed_generator, feed_name="openai_research"):
-    """Save RSS feed to an XML file."""
-    feeds_dir = Path("feeds")
-    feeds_dir.mkdir(exist_ok=True)
-    output_file = feeds_dir / f"feed_{feed_name}.xml"
-    feed_generator.rss_file(str(output_file), pretty=True)
-    logger.info(f"RSS feed saved to {output_file}")
-    return output_file
-
-
-def main():
+def main(full_reset=False):
     """Main function to generate OpenAI Research News RSS feed."""
     url = "https://openai.com/news/research/?limit=500"
 
@@ -146,7 +126,7 @@ def main():
         if not articles:
             logger.warning("No articles were parsed. Check your selectors.")
         feed = generate_rss_feed(articles)
-        save_rss_feed(feed)
+        save_rss_feed(feed, FEED_NAME)
     except Exception as e:
         logger.error(f"Failed to generate RSS feed: {e}")
 

--- a/feed_generators/paulgraham_blog.py
+++ b/feed_generators/paulgraham_blog.py
@@ -1,51 +1,22 @@
-import os
-import requests
-from bs4 import BeautifulSoup
-from datetime import datetime, timedelta
-import pytz
-from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 import re
+from datetime import datetime
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+import pytz
+from bs4 import BeautifulSoup
+from feedgen.feed import FeedGenerator
+
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    stable_fallback_date,
 )
-logger = logging.getLogger(__name__)
 
+logger = setup_logging()
 
-def stable_fallback_date(identifier):
-    """Generate a stable date from a URL or title hash."""
-    hash_val = abs(hash(identifier)) % 730
-    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
-    return epoch + timedelta(days=hash_val)
-
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def fetch_html_content(url):
-    """Fetch HTML content from the given URL."""
-    try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
-        logger.error(f"Error fetching content from {url}: {str(e)}")
-        raise
+FEED_NAME = "paulgraham"
+BLOG_URL = "https://paulgraham.com/articles.html"
 
 
 def extract_date_from_text(text):
@@ -138,7 +109,7 @@ def parse_essays_page(html_content, base_url="https://paulgraham.com", max_essay
             logger.info(f"Fetching article: {title}")
 
             # Fetch article content once and reuse it
-            article_html = fetch_html_content(full_url)
+            article_html = fetch_page(full_url)
             content, pub_date = get_article_content(article_html)
 
             if content:
@@ -150,7 +121,7 @@ def parse_essays_page(html_content, base_url="https://paulgraham.com", max_essay
                 "title": title,
                 "link": full_url,
                 "description": description,
-                "pub_date": pub_date
+                "date": pub_date
                 or stable_fallback_date(
                     full_url
                 ),  # Fallback to stable date if none found
@@ -172,20 +143,18 @@ def parse_essays_page(html_content, base_url="https://paulgraham.com", max_essay
         raise
 
 
-def generate_rss_feed(blog_posts, feed_name="paulgraham"):
+def generate_rss_feed(blog_posts):
     """Generate RSS feed from blog posts."""
     try:
         fg = FeedGenerator()
         fg.title("Paul Graham Essays")
         fg.description("Essays by Paul Graham")
-        fg.link(href="https://paulgraham.com/articles.html")
         fg.language("en")
 
         # Set feed metadata
         fg.author({"name": "Paul Graham"})
         fg.subtitle("Paul Graham's Essays and Writings")
-        fg.link(href="https://paulgraham.com/articles.html", rel="alternate")
-        fg.link(href=f"https://paulgraham.com/feed_{feed_name}.xml", rel="self")
+        setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
 
         # Add entries
         for post in blog_posts:
@@ -193,7 +162,7 @@ def generate_rss_feed(blog_posts, feed_name="paulgraham"):
             fe.title(post["title"])
             fe.description(post["description"])
             fe.link(href=post["link"])
-            fe.published(post["pub_date"])
+            fe.published(post["date"])
             fe.id(post["link"])
 
         logger.info("Successfully generated RSS feed")
@@ -204,34 +173,20 @@ def generate_rss_feed(blog_posts, feed_name="paulgraham"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="paulgraham"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        feeds_dir = ensure_feeds_directory()
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(blog_url="https://paulgraham.com/articles.html", feed_name="paulgraham"):
+def main():
     """Main function to generate RSS feed from blog URL."""
     try:
         # Fetch blog content
-        html_content = fetch_html_content(blog_url)
+        html_content = fetch_page(BLOG_URL)
 
         # Parse blog posts
         blog_posts = parse_essays_page(html_content)
 
         # Generate RSS feed
-        feed = generate_rss_feed(blog_posts, feed_name)
+        feed = generate_rss_feed(blog_posts)
 
         # Save feed to file
-        _output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, FEED_NAME)
 
         return True
 

--- a/feed_generators/test_feed.py
+++ b/feed_generators/test_feed.py
@@ -1,41 +1,20 @@
-import requests
-import xml.etree.ElementTree as ET
-from bs4 import BeautifulSoup
 from datetime import datetime
+
 import pytz
+from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+)
 
+logger = setup_logging()
 
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def fetch_news_content(url="https://www.anthropic.com/news"):
-    """Fetch news content from Anthropic's website."""
-    try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
-        logger.error(f"Error fetching news content: {str(e)}")
-        raise
+FEED_NAME = "anthropic"
+BLOG_URL = "https://www.anthropic.com/news"
 
 
 def parse_news_html(html_content):
@@ -89,21 +68,19 @@ def parse_news_html(html_content):
         raise
 
 
-def generate_rss_feed(articles, feed_name="anthropic"):
+def generate_rss_feed(articles):
     """Generate RSS feed from news articles."""
     try:
         fg = FeedGenerator()
         fg.title("Anthropic News")
         fg.description("Latest news and updates from Anthropic")
-        fg.link(href="https://www.anthropic.com/news")
         fg.language("en")
 
         # Set feed metadata
         fg.author({"name": "Anthropic"})
         fg.logo("https://www.anthropic.com/images/icons/apple-touch-icon.png")
         fg.subtitle("Latest updates from Anthropic's newsroom")
-        fg.link(href="https://www.anthropic.com/news", rel="alternate")
-        fg.link(href=f"https://anthropic.com/news/feed_{feed_name}.xml", rel="self")
+        setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
 
         # Add entries
         for article in articles:
@@ -123,27 +100,10 @@ def generate_rss_feed(articles, feed_name="anthropic"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="anthropic"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        # Ensure feeds directory exists and get its path
-        feeds_dir = ensure_feeds_directory()
-
-        # Create the output file path
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-
-        # Save the feed
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
 def get_existing_links_from_feed(feed_path):
     """Parse the existing RSS feed and return a set of all article links."""
+    import xml.etree.ElementTree as ET
+
     existing_links = set()
     try:
         if not feed_path.exists():
@@ -160,20 +120,20 @@ def get_existing_links_from_feed(feed_path):
     return existing_links
 
 
-def main(feed_name="anthropic"):
+def main():
     """Main function to generate RSS feed from Anthropic's news page."""
     try:
         # Fetch news content
-        html_content = fetch_news_content()
+        html_content = fetch_page(BLOG_URL)
 
         # Parse articles from HTML
         articles = parse_news_html(html_content)
 
         # Generate RSS feed with all articles
-        feed = generate_rss_feed(articles, feed_name)
+        feed = generate_rss_feed(articles)
 
         # Save feed to file
-        output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, FEED_NAME)
 
         logger.info(f"Successfully generated RSS feed with {len(articles)} articles")
         return True

--- a/feed_generators/thinkingmachines_blog.py
+++ b/feed_generators/thinkingmachines_blog.py
@@ -1,53 +1,25 @@
 import os
-import requests
-from bs4 import BeautifulSoup
-from datetime import datetime, timedelta
+import sys
+from datetime import datetime
+
 import pytz
+from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
-from dateutil import parser
 
-from utils import sort_posts_for_feed
-
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+from utils import (
+    fetch_page,
+    get_project_root,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+    stable_fallback_date,
 )
-logger = logging.getLogger(__name__)
 
+logger = setup_logging()
 
-def stable_fallback_date(identifier):
-    """Generate a stable date from a URL or title hash."""
-    hash_val = abs(hash(identifier)) % 730
-    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
-    return epoch + timedelta(days=hash_val)
-
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def fetch_content(url):
-    """Fetch content from website."""
-    try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
-        logger.error(f"Error fetching content from {url}: {str(e)}")
-        raise
+FEED_NAME = "thinkingmachines"
+BLOG_URL = "https://thinkingmachines.ai/blog/"
 
 
 def parse_date(date_text):
@@ -136,7 +108,7 @@ def extract_articles(soup):
                 "title": title,
                 "link": link,
                 "description": f"{title} by {author_text}",
-                "pub_date": pub_date,
+                "date": pub_date,
                 "author": author_text,
             }
 
@@ -148,7 +120,7 @@ def extract_articles(soup):
             continue
 
     # Sort for correct feed order (newest first in output)
-    articles = sort_posts_for_feed(articles, date_field="pub_date")
+    articles = sort_posts_for_feed(articles)
 
     logger.info(f"Successfully parsed {len(articles)} articles")
     return articles
@@ -164,7 +136,7 @@ def parse_html(html_content):
         raise
 
 
-def generate_rss_feed(articles, feed_name="thinkingmachines"):
+def generate_rss_feed(articles):
     """Generate RSS feed using feedgen."""
     try:
         fg = FeedGenerator()
@@ -172,14 +144,12 @@ def generate_rss_feed(articles, feed_name="thinkingmachines"):
         fg.description(
             "Research blog by Thinking Machines Lab - Shared science and news from the team"
         )
-        fg.link(href="https://thinkingmachines.ai/blog/")
         fg.language("en")
 
         # Set feed metadata
         fg.author({"name": "Thinking Machines Lab"})
         fg.subtitle("Shared science and news from the team")
-        fg.link(href="https://thinkingmachines.ai/blog/", rel="alternate")
-        fg.link(href=f"https://thinkingmachines.ai/feed_{feed_name}.xml", rel="self")
+        setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
 
         # Add entries
         for article in articles:
@@ -187,7 +157,7 @@ def generate_rss_feed(articles, feed_name="thinkingmachines"):
             fe.title(article["title"])
             fe.description(article["description"])
             fe.link(href=article["link"])
-            fe.published(article["pub_date"])
+            fe.published(article["date"])
             fe.author({"name": article["author"]})
             fe.id(article["link"])
 
@@ -199,21 +169,7 @@ def generate_rss_feed(articles, feed_name="thinkingmachines"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="thinkingmachines"):
-    """Save feed to XML file."""
-    try:
-        feeds_dir = ensure_feeds_directory()
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(feed_name="thinkingmachines", html_file=None):
+def main(html_file=None):
     """Main entry point with local file support."""
     try:
         # Check for local HTML file
@@ -240,16 +196,16 @@ def main(feed_name="thinkingmachines", html_file=None):
             if not local_file_found:
                 # Fetch from website
                 logger.info("Fetching content from website")
-                html_content = fetch_content("https://thinkingmachines.ai/blog/")
+                html_content = fetch_page(BLOG_URL)
 
         # Parse articles
         articles = parse_html(html_content)
 
         # Generate RSS feed
-        feed = generate_rss_feed(articles, feed_name)
+        feed = generate_rss_feed(articles)
 
         # Save feed to file
-        _output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, FEED_NAME)
 
         logger.info(f"Successfully generated RSS feed with {len(articles)} articles")
         return True
@@ -260,7 +216,5 @@ def main(feed_name="thinkingmachines", html_file=None):
 
 
 if __name__ == "__main__":
-    import sys
-
     html_file = sys.argv[1] if len(sys.argv) > 1 else None
     main(html_file=html_file)

--- a/feed_generators/utils.py
+++ b/feed_generators/utils.py
@@ -1,6 +1,5 @@
 """Shared utilities for feed generators."""
 
-import argparse
 import json
 import logging
 import re
@@ -29,7 +28,7 @@ DEFAULT_HEADERS = {"User-Agent": DEFAULT_USER_AGENT}
 # ---------------------------------------------------------------------------
 
 
-def setup_logging() -> logging.Logger:
+def setup_logging(name: str | None = None) -> logging.Logger:
     """Configure logging and return a logger for the calling module.
 
     Call once at module level: ``logger = setup_logging()``
@@ -38,7 +37,10 @@ def setup_logging() -> logging.Logger:
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
-    return logging.getLogger(__name__)
+    if name is None:
+        import inspect
+        name = inspect.stack()[1].f_globals.get("__name__", __name__)
+    return logging.getLogger(name)
 
 
 logger = setup_logging()
@@ -294,28 +296,6 @@ def save_rss_feed(fg: FeedGenerator, feed_name: str) -> Path:
     logger.info(f"Saved RSS feed to {output_file}")
     return output_file
 
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
-
-
-def create_feed_cli(description: str) -> argparse.Namespace:
-    """Create a standard feed generator CLI with ``--full`` flag.
-
-    Args:
-        description: Help text for the generator script.
-
-    Returns:
-        Parsed arguments namespace with ``full`` attribute.
-    """
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        "--full",
-        action="store_true",
-        help="Force full reset (fetch all pages instead of incremental)",
-    )
-    return parser.parse_args()
 
 
 # ---------------------------------------------------------------------------

--- a/feed_generators/utils.py
+++ b/feed_generators/utils.py
@@ -1,28 +1,238 @@
 """Shared utilities for feed generators."""
 
+import argparse
+import json
+import logging
+import re
+import subprocess
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+import pytz
+import requests
 from feedgen.feed import FeedGenerator
 
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
 
-def get_project_root():
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/137.0.0.0 Safari/537.36"
+)
+DEFAULT_HEADERS = {"User-Agent": DEFAULT_USER_AGENT}
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+def setup_logging() -> logging.Logger:
+    """Configure logging and return a logger for the calling module.
+
+    Call once at module level: ``logger = setup_logging()``
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+    return logging.getLogger(__name__)
+
+
+logger = setup_logging()
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def get_project_root() -> Path:
     """Get the project root directory."""
     return Path(__file__).parent.parent
 
 
-def get_cache_dir():
+def get_cache_dir() -> Path:
     """Get the cache directory path, creating it if needed."""
     cache_dir = get_project_root() / "cache"
     cache_dir.mkdir(exist_ok=True)
     return cache_dir
 
 
-def get_feeds_dir():
+def get_feeds_dir() -> Path:
     """Get the feeds directory path, creating it if needed."""
     feeds_dir = get_project_root() / "feeds"
     feeds_dir.mkdir(exist_ok=True)
     return feeds_dir
+
+
+def get_cache_file(feed_name: str) -> Path:
+    """Get the cache file path for a feed.
+
+    Args:
+        feed_name: Feed identifier (e.g., "dagster", "cursor")
+
+    Returns:
+        Path to ``cache/<feed_name>_posts.json``
+    """
+    return get_cache_dir() / f"{feed_name}_posts.json"
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+# ---------------------------------------------------------------------------
+
+
+def fetch_page(url: str, timeout: int = 30, headers: dict | None = None) -> str:
+    """Fetch a page and return its HTML content.
+
+    Args:
+        url: URL to fetch
+        timeout: Request timeout in seconds
+        headers: Optional headers dict. Falls back to DEFAULT_HEADERS.
+
+    Returns:
+        Response text (HTML)
+    """
+    if headers is None:
+        headers = DEFAULT_HEADERS
+    response = requests.get(url, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    return response.text
+
+
+# ---------------------------------------------------------------------------
+# Date helpers
+# ---------------------------------------------------------------------------
+
+
+def stable_fallback_date(identifier: str) -> datetime:
+    """Generate a stable date from a URL or title hash.
+
+    Used when a post has no parseable date. The hash ensures the same
+    identifier always produces the same fallback date, preventing
+    cache churn.
+    """
+    hash_val = abs(hash(identifier)) % 730
+    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
+    return epoch + timedelta(days=hash_val)
+
+
+# ---------------------------------------------------------------------------
+# Cache management
+# ---------------------------------------------------------------------------
+
+
+def load_cache(feed_name: str, entries_key: str = "entries") -> dict:
+    """Load existing cache or return empty structure.
+
+    Args:
+        feed_name: Feed identifier used to locate the cache file.
+        entries_key: Key under which entries are stored (default "entries").
+
+    Returns:
+        Dict with ``last_updated`` and the entries list.
+    """
+    cache_file = get_cache_file(feed_name)
+    if cache_file.exists():
+        try:
+            with open(cache_file, "r") as f:
+                data = json.load(f)
+                logger.info(f"Loaded cache with {len(data.get(entries_key, []))} entries")
+                return data
+        except json.JSONDecodeError:
+            logger.warning(f"Corrupted cache file {cache_file}, starting fresh")
+    logger.info("No cache file found, will do full fetch")
+    return {"last_updated": None, entries_key: []}
+
+
+def save_cache(feed_name: str, entries: list[dict], entries_key: str = "entries") -> None:
+    """Save entries to cache file with automatic datetime serialization.
+
+    Args:
+        feed_name: Feed identifier used to locate the cache file.
+        entries: List of entry dicts to cache.
+        entries_key: Key under which entries are stored (default "entries").
+    """
+    cache_file = get_cache_file(feed_name)
+    serializable = []
+    for entry in entries:
+        entry_copy = entry.copy()
+        for key, value in entry_copy.items():
+            if isinstance(value, datetime):
+                entry_copy[key] = value.isoformat()
+        serializable.append(entry_copy)
+
+    data = {
+        "last_updated": datetime.now(pytz.UTC).isoformat(),
+        entries_key: serializable,
+    }
+    with open(cache_file, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    logger.info(f"Saved cache with {len(entries)} entries to {cache_file}")
+
+
+def deserialize_entries(
+    entries: list[dict], date_field: str = "date"
+) -> list[dict]:
+    """Convert cached entries back to proper format with datetime objects.
+
+    Args:
+        entries: List of entry dicts from cache.
+        date_field: Key name for the date field to deserialize.
+
+    Returns:
+        Entries with ISO date strings converted back to datetime objects.
+    """
+    result = []
+    for entry in entries:
+        entry_copy = entry.copy()
+        if isinstance(entry_copy.get(date_field), str):
+            try:
+                entry_copy[date_field] = datetime.fromisoformat(entry_copy[date_field])
+            except ValueError:
+                entry_copy[date_field] = stable_fallback_date(
+                    entry_copy.get("link", "")
+                )
+        result.append(entry_copy)
+    return result
+
+
+def merge_entries(
+    new_entries: list[dict],
+    cached_entries: list[dict],
+    id_field: str = "link",
+    date_field: str = "date",
+) -> list[dict]:
+    """Merge new entries into cache, deduplicate, and sort.
+
+    Args:
+        new_entries: Freshly fetched entries.
+        cached_entries: Previously cached entries.
+        id_field: Field used for deduplication (default "link").
+        date_field: Field used for sorting (default "date").
+
+    Returns:
+        Merged and sorted list of entries.
+    """
+    existing_ids = {e[id_field] for e in cached_entries}
+    merged = list(cached_entries)
+
+    added_count = 0
+    for entry in new_entries:
+        if entry[id_field] not in existing_ids:
+            merged.append(entry)
+            existing_ids.add(entry[id_field])
+            added_count += 1
+
+    logger.info(f"Added {added_count} new entries to cache")
+    return sort_posts_for_feed(merged, date_field=date_field)
+
+
+# ---------------------------------------------------------------------------
+# Feed generation
+# ---------------------------------------------------------------------------
 
 
 def setup_feed_links(fg: FeedGenerator, blog_url: str, feed_name: str) -> None:
@@ -37,16 +247,16 @@ def setup_feed_links(fg: FeedGenerator, blog_url: str, feed_name: str) -> None:
         blog_url: URL to the original blog (e.g., "https://dagster.io/blog")
         feed_name: Feed name for the self link (e.g., "dagster")
     """
-    # Self link first - this becomes <atom:link rel="self">
     fg.link(
         href=f"https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_{feed_name}.xml",
         rel="self",
     )
-    # Alternate link last - this becomes the main <link>
     fg.link(href=blog_url, rel="alternate")
 
 
-def sort_posts_for_feed(posts: list[dict[str, Any]], date_field: str = "date") -> list[dict[str, Any]]:
+def sort_posts_for_feed(
+    posts: list[dict[str, Any]], date_field: str = "date"
+) -> list[dict[str, Any]]:
     """Sort posts so newest appears first in the final RSS feed.
 
     IMPORTANT: feedgen reverses the order when writing entries to XML.
@@ -60,12 +270,101 @@ def sort_posts_for_feed(posts: list[dict[str, Any]], date_field: str = "date") -
     Returns:
         Sorted list with posts ordered for correct feed output
     """
-    # Separate posts with and without dates
     posts_with_date = [p for p in posts if p.get(date_field) is not None]
     posts_without_date = [p for p in posts if p.get(date_field) is None]
 
-    # Sort ascending (oldest first) - feedgen will reverse this
-    posts_with_date.sort(key=lambda x: x[date_field], reverse=False)
+    posts_with_date.sort(key=lambda x: x[date_field])
 
-    # Posts without dates go at the end
     return posts_with_date + posts_without_date
+
+
+def save_rss_feed(fg: FeedGenerator, feed_name: str) -> Path:
+    """Save an RSS feed to the feeds directory.
+
+    Args:
+        fg: Configured FeedGenerator instance.
+        feed_name: Feed identifier (e.g., "dagster").
+
+    Returns:
+        Path to the written XML file.
+    """
+    feeds_dir = get_feeds_dir()
+    output_file = feeds_dir / f"feed_{feed_name}.xml"
+    fg.rss_file(str(output_file), pretty=True)
+    logger.info(f"Saved RSS feed to {output_file}")
+    return output_file
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def create_feed_cli(description: str) -> argparse.Namespace:
+    """Create a standard feed generator CLI with ``--full`` flag.
+
+    Args:
+        description: Help text for the generator script.
+
+    Returns:
+        Parsed arguments namespace with ``full`` attribute.
+    """
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Force full reset (fetch all pages instead of incremental)",
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Chrome / Selenium
+# ---------------------------------------------------------------------------
+
+
+def get_chrome_major_version() -> int | None:
+    """Detect the installed Chrome major version.
+
+    Returns the major version number (e.g., 146) or None if detection fails.
+    This is needed because undetected_chromedriver auto-downloads the latest
+    chromedriver, which may not match the installed Chrome version.
+    """
+    chrome_paths = [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "google-chrome",
+        "google-chrome-stable",
+    ]
+    for path in chrome_paths:
+        try:
+            result = subprocess.run(
+                [path, "--version"], capture_output=True, text=True, timeout=5
+            )
+            match = re.search(r"(\d+)\.", result.stdout)
+            if match:
+                version = int(match.group(1))
+                logger.info(f"Detected Chrome major version: {version}")
+                return version
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+    logger.warning("Could not detect Chrome version, using undetected_chromedriver default")
+    return None
+
+
+def setup_selenium_driver():
+    """Set up a headless Selenium WebDriver with undetected-chromedriver.
+
+    Automatically detects the installed Chrome version to avoid
+    chromedriver version mismatches.
+    """
+    import undetected_chromedriver as uc
+
+    options = uc.ChromeOptions()
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--window-size=1920,1080")
+    options.add_argument("--disable-blink-features=AutomationControlled")
+    options.add_argument(f"--user-agent={DEFAULT_USER_AGENT}")
+    version = get_chrome_major_version()
+    return uc.Chrome(options=options, version_main=version)

--- a/feed_generators/windsurf_blog.py
+++ b/feed_generators/windsurf_blog.py
@@ -1,27 +1,20 @@
-import requests
 from datetime import datetime
+
 import pytz
+import requests
 from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 
-from utils import sort_posts_for_feed
+from utils import (
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+)
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+logger = setup_logging()
 
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
+FEED_NAME = "windsurf_blog"  # keep _blog suffix for backwards compatibility (feed URL)
+BLOG_URL = "https://windsurf.com/blog"
 
 
 def fetch_blog_posts():
@@ -91,19 +84,17 @@ def parse_blog_posts(api_response):
         raise
 
 
-def generate_rss_feed(blog_posts, feed_name="windsurf_blog"):
+def generate_rss_feed(blog_posts, feed_name=FEED_NAME):
     """Generate RSS feed from blog posts."""
     try:
         fg = FeedGenerator()
         fg.title("Windsurf Blog")
         fg.description("Latest updates and announcements from Windsurf")
-        fg.link(href="https://windsurf.com/blog")
+        setup_feed_links(fg, BLOG_URL, feed_name)
         fg.language("en")
 
         fg.author({"name": "Windsurf"})
         fg.subtitle("Read about the latest announcements from Windsurf")
-        fg.link(href="https://windsurf.com/blog", rel="alternate")
-        fg.link(href=f"https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_{feed_name}.xml", rel="self")
 
         # Sort for correct feed order (newest first in output)
         blog_posts_sorted = sort_posts_for_feed(blog_posts, date_field="date")
@@ -128,20 +119,7 @@ def generate_rss_feed(blog_posts, feed_name="windsurf_blog"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="windsurf_blog"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        feeds_dir = ensure_feeds_directory()
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(feed_name="windsurf_blog"):
+def main(feed_name=FEED_NAME):
     """Main function to generate RSS feed from Windsurf blog."""
     try:
         api_response = fetch_blog_posts()
@@ -152,7 +130,7 @@ def main(feed_name="windsurf_blog"):
             return False
 
         feed = generate_rss_feed(blog_posts, feed_name)
-        output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, feed_name)
 
         logger.info(f"Successfully generated RSS feed with {len(blog_posts)} posts")
         return True

--- a/feed_generators/windsurf_changelog.py
+++ b/feed_generators/windsurf_changelog.py
@@ -1,41 +1,29 @@
-import requests
-from bs4 import BeautifulSoup
-from datetime import datetime
-import pytz
-from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 import re
+from datetime import datetime
 
-from utils import sort_posts_for_feed
+import pytz
+from bs4 import BeautifulSoup
+from feedgen.feed import FeedGenerator
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+)
+
+logger = setup_logging()
+
+FEED_NAME = "windsurf_changelog"
+BLOG_URL = "https://windsurf.com/changelog"
 
 
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def fetch_changelog_content(url="https://windsurf.com/changelog"):
+def fetch_changelog_content(url=BLOG_URL):
     """Fetch changelog content from Windsurf's website."""
     try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
+        return fetch_page(url)
+    except Exception as e:
         logger.error(f"Error fetching changelog content: {str(e)}")
         raise
 
@@ -145,19 +133,17 @@ def parse_changelog_html(html_content):
         raise
 
 
-def generate_rss_feed(changelog_entries, feed_name="windsurf_changelog"):
+def generate_rss_feed(changelog_entries, feed_name=FEED_NAME):
     """Generate RSS feed from changelog entries."""
     try:
         fg = FeedGenerator()
         fg.title("Windsurf Changelog")
         fg.description("Version updates and changes from Windsurf")
-        fg.link(href="https://windsurf.com/changelog")
+        setup_feed_links(fg, BLOG_URL, feed_name)
         fg.language("en")
 
         fg.author({"name": "Windsurf"})
         fg.subtitle("Latest version updates from Windsurf")
-        fg.link(href="https://windsurf.com/changelog", rel="alternate")
-        fg.link(href=f"https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_{feed_name}.xml", rel="self")
 
         # Sort for correct feed order (newest first in output)
         entries_sorted = sort_posts_for_feed(changelog_entries, date_field="date")
@@ -179,20 +165,7 @@ def generate_rss_feed(changelog_entries, feed_name="windsurf_changelog"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="windsurf_changelog"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        feeds_dir = ensure_feeds_directory()
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(feed_name="windsurf_changelog"):
+def main(feed_name=FEED_NAME):
     """Main function to generate RSS feed from Windsurf changelog."""
     try:
         html_content = fetch_changelog_content()
@@ -203,7 +176,7 @@ def main(feed_name="windsurf_changelog"):
             return False
 
         feed = generate_rss_feed(changelog_entries, feed_name)
-        output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, feed_name)
 
         logger.info(f"Successfully generated RSS feed with {len(changelog_entries)} entries")
         return True

--- a/feed_generators/windsurf_next_changelog.py
+++ b/feed_generators/windsurf_next_changelog.py
@@ -1,41 +1,29 @@
-import requests
-from bs4 import BeautifulSoup
-from datetime import datetime
-import pytz
-from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 import re
+from datetime import datetime
 
-from utils import sort_posts_for_feed
+import pytz
+from bs4 import BeautifulSoup
+from feedgen.feed import FeedGenerator
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+from utils import (
+    fetch_page,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+)
+
+logger = setup_logging()
+
+FEED_NAME = "windsurf_next_changelog"
+BLOG_URL = "https://windsurf.com/changelog/windsurf-next"
 
 
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def fetch_changelog_content(url="https://windsurf.com/changelog/windsurf-next"):
+def fetch_changelog_content(url=BLOG_URL):
     """Fetch changelog content from Windsurf Next's website."""
     try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
+        return fetch_page(url)
+    except Exception as e:
         logger.error(f"Error fetching changelog content: {str(e)}")
         raise
 
@@ -145,19 +133,17 @@ def parse_changelog_html(html_content):
         raise
 
 
-def generate_rss_feed(changelog_entries, feed_name="windsurf_next_changelog"):
+def generate_rss_feed(changelog_entries, feed_name=FEED_NAME):
     """Generate RSS feed from changelog entries."""
     try:
         fg = FeedGenerator()
         fg.title("Windsurf Next Changelog")
         fg.description("Version updates and changes from Windsurf Next")
-        fg.link(href="https://windsurf.com/changelog/windsurf-next")
+        setup_feed_links(fg, BLOG_URL, feed_name)
         fg.language("en")
 
         fg.author({"name": "Windsurf"})
         fg.subtitle("Latest version updates from Windsurf Next")
-        fg.link(href="https://windsurf.com/changelog/windsurf-next", rel="alternate")
-        fg.link(href=f"https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_{feed_name}.xml", rel="self")
 
         # Sort for correct feed order (newest first in output)
         entries_sorted = sort_posts_for_feed(changelog_entries, date_field="date")
@@ -179,20 +165,7 @@ def generate_rss_feed(changelog_entries, feed_name="windsurf_next_changelog"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="windsurf_next_changelog"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        feeds_dir = ensure_feeds_directory()
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(feed_name="windsurf_next_changelog"):
+def main(feed_name=FEED_NAME):
     """Main function to generate RSS feed from Windsurf Next changelog."""
     try:
         html_content = fetch_changelog_content()
@@ -203,7 +176,7 @@ def main(feed_name="windsurf_next_changelog"):
             return False
 
         feed = generate_rss_feed(changelog_entries, feed_name)
-        output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, feed_name)
 
         logger.info(f"Successfully generated RSS feed with {len(changelog_entries)} entries")
         return True

--- a/feed_generators/xainews_blog.py
+++ b/feed_generators/xainews_blog.py
@@ -1,52 +1,29 @@
-import requests
-import xml.etree.ElementTree as ET
-from bs4 import BeautifulSoup
-from datetime import datetime, timedelta
+import sys
+from datetime import datetime
+
 import pytz
+from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
-import logging
-from pathlib import Path
 
-from utils import sort_posts_for_feed
-
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+from utils import (
+    fetch_page,
+    get_project_root,
+    save_rss_feed,
+    setup_feed_links,
+    setup_logging,
+    sort_posts_for_feed,
+    stable_fallback_date,
 )
-logger = logging.getLogger(__name__)
+
+logger = setup_logging()
+
+FEED_NAME = "xainews"
+BLOG_URL = "https://x.ai/news"
 
 
-def stable_fallback_date(identifier):
-    """Generate a stable date from a URL or title hash."""
-    hash_val = abs(hash(identifier)) % 730
-    epoch = datetime(2023, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
-    return epoch + timedelta(days=hash_val)
-
-
-def get_project_root():
-    """Get the project root directory."""
-    return Path(__file__).parent.parent
-
-
-def ensure_feeds_directory():
-    """Ensure the feeds directory exists."""
-    feeds_dir = get_project_root() / "feeds"
-    feeds_dir.mkdir(exist_ok=True)
-    return feeds_dir
-
-
-def fetch_news_content(url="https://x.ai/news"):
+def fetch_news_content(url=BLOG_URL):
     """Fetch news content from xAI's website."""
-    try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        }
-        response = requests.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
-        logger.error(f"Error fetching news content: {str(e)}")
-        raise
+    return fetch_page(url, timeout=10)
 
 
 def parse_date(date_text):
@@ -234,20 +211,18 @@ def parse_news_html(html_content):
         raise
 
 
-def generate_rss_feed(articles, feed_name="xainews"):
+def generate_rss_feed(articles):
     """Generate RSS feed from news articles."""
     try:
         fg = FeedGenerator()
         fg.title("xAI News")
         fg.description("Latest news and updates from xAI")
-        fg.link(href="https://x.ai/news")
         fg.language("en")
 
         # Set feed metadata
         fg.author({"name": "xAI"})
         fg.subtitle("Latest updates from xAI")
-        fg.link(href="https://x.ai/news", rel="alternate")
-        fg.link(href=f"https://x.ai/news/feed_{feed_name}.xml", rel="self")
+        setup_feed_links(fg, blog_url=BLOG_URL, feed_name=FEED_NAME)
 
         # Sort articles for correct feed order (newest first in output)
         articles_sorted = sort_posts_for_feed(articles, date_field="date")
@@ -270,30 +245,11 @@ def generate_rss_feed(articles, feed_name="xainews"):
         raise
 
 
-def save_rss_feed(feed_generator, feed_name="xainews"):
-    """Save the RSS feed to a file in the feeds directory."""
-    try:
-        # Ensure feeds directory exists and get its path
-        feeds_dir = ensure_feeds_directory()
-
-        # Create the output file path
-        output_filename = feeds_dir / f"feed_{feed_name}.xml"
-
-        # Save the feed
-        feed_generator.rss_file(str(output_filename), pretty=True)
-        logger.info(f"Successfully saved RSS feed to {output_filename}")
-        return output_filename
-
-    except Exception as e:
-        logger.error(f"Error saving RSS feed: {str(e)}")
-        raise
-
-
-def main(feed_name="xainews", html_file=None):
+def main(full_reset=False, html_file=None):
     """Main function to generate RSS feed from xAI's news page.
 
     Args:
-        feed_name: Name of the feed (default: "xainews")
+        full_reset: Unused, kept for interface consistency.
         html_file: Optional path to local HTML file to parse instead of fetching from web
     """
     try:
@@ -314,10 +270,10 @@ def main(feed_name="xainews", html_file=None):
             return False
 
         # Generate RSS feed with all articles
-        feed = generate_rss_feed(articles, feed_name)
+        feed = generate_rss_feed(articles)
 
         # Save feed to file
-        output_file = save_rss_feed(feed, feed_name)
+        save_rss_feed(feed, FEED_NAME)
 
         logger.info(f"Successfully generated RSS feed with {len(articles)} articles")
         return True
@@ -328,7 +284,7 @@ def main(feed_name="xainews", html_file=None):
 
 
 if __name__ == "__main__":
-    import sys
+    from pathlib import Path
 
     # Check if HTML file path was provided as argument
     html_file = None


### PR DESCRIPTION
## Summary

Extract ~980 lines of duplicated boilerplate from all 22 generators into shared `utils.py` functions. Standardize field names across caching generators for consistency.

## Changes

### utils.py expansion (+309 lines)
New shared functions and constants:
- `DEFAULT_USER_AGENT` / `DEFAULT_HEADERS` - single source of truth for Chrome user-agent
- `setup_logging()` - replaces 21 identical logging.basicConfig blocks
- `fetch_page(url, timeout, headers)` - replaces 13 identical fetch functions
- `stable_fallback_date(identifier)` - was copy-pasted in 10 files
- `get_cache_file(feed_name)` - was copy-pasted in 5 files
- `load_cache()` / `save_cache()` - were copy-pasted in 5 files, with auto datetime serialization
- `deserialize_entries()` / `merge_entries()` - were copy-pasted in 5 files
- `save_rss_feed(fg, feed_name)` - was copy-pasted in 20 files
- `get_chrome_major_version()` / `setup_selenium_driver()` - were copy-pasted in 3 files

### Field name standardization (5 caching generators)
- URL field: `"url"` -> `"link"` (claude, cursor, dagster)
- Cache key: `"posts"` / `"articles"` -> `"entries"` (all 5)
- Date field: `"pub_date"` / `"published"` -> `"date"` (6 generators)
- Function names: `merge_posts()` / `merge_articles()` -> `merge_entries()`

### Per-generator cleanup
- Added `FEED_NAME` / `BLOG_URL` constants to 15 generators that hardcoded URLs
- Fixed bare `except:` in anthropic_research_blog.py
- Replaced `print()` with `logger` in blogsurgeai_feed_generator.py
- Moved inline `import re` to top-level in anthropic_eng_blog.py
- Removed 3 duplicate `setup_selenium_driver()` definitions
- Fixed import ordering across all files
- Fixed self-link URLs (several had wrong URLs like `anthropic.com/feed_*.xml`)

### Net result
- **-670 lines** net across the codebase
- Every generator now follows the same structure: constants at top, utils imports, business logic only

## Cache migration note

The field rename (`"posts"` -> `"entries"`) means existing cache files will appear empty to the new code. All 5 caching generators handle this gracefully: empty cache triggers an automatic full fetch. The first CI run after merge will be slightly slower (full scrape instead of incremental), then subsequent runs are incremental as before. No manual action needed.

## Test plan

- [x] All 21 generators pass locally (`run_all_feeds.py --skip-selenium`)
- [x] All feed XMLs validated (correct `<link>`, correct `atom:link rel="self"`)
- [x] All files compile without errors
- [ ] Trigger `Run Feeds` workflow on PR branch


🤖 Generated with [Claude Code](https://claude.com/claude-code)