### PR TITLE
[REVIEW] Fix generator bugs, replace sleep with WebDriverWait, migrate to uv run

### DIFF
--- a/.agents/skills/cmd-rss-feed-generator/SKILL.md
+++ b/.agents/skills/cmd-rss-feed-generator/SKILL.md
@@ -117,7 +117,7 @@ Add a new target to `makefiles/feeds.mk` following the existing pattern:
 feeds_new_site: ## Generate RSS feed for NewSite
    $(call check_venv)
    $(call print_info,Generating NewSite feed)
-   $(Q)python feed_generators/new_site_blog.py
+   $(Q)uv run feed_generators/new_site_blog.py
    $(call print_success,NewSite feed generated)
 ```
 
@@ -128,7 +128,7 @@ Also add a legacy alias in the main `Makefile` following the existing pattern.
 1. **Test with local HTML** (if site blocks requests):
 
    ```bash
-   python feed_generators/new_site_blog.py blog.html
+   uv run feed_generators/new_site_blog.py blog.html
    ```
 
 2. **Test with Makefile**:

--- a/.github/workflows/validate_feeds.yml
+++ b/.github/workflows/validate_feeds.yml
@@ -23,5 +23,12 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Validate all feeds
-        run: python feed_generators/validate_feeds.py
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies and validate all feeds
+        run: |
+          uv sync
+          uv run feed_generators/validate_feeds.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ make dev_format           # Alias for dev_lint_fix
 make dev_test_feed        # Run test feed generator
 
 # Run single generator directly
-python feed_generators/ollama_blog.py
+uv run feed_generators/ollama_blog.py
 
 # CI/CD
 make ci_trigger_feeds_workflow    # Trigger GitHub Action manually
@@ -194,13 +194,13 @@ Claude will:
 make env_setup
 
 # Run the generator
-python feed_generators/<source>_blog.py
+uv run feed_generators/<source>_blog.py
 
 # Verify output
 cat feeds/feed_<source>.xml | head -50
 
 # For paginated feeds, test full fetch
-python feed_generators/<source>_blog.py --full
+uv run feed_generators/<source>_blog.py --full
 ```
 
 **Verify**:
@@ -217,7 +217,7 @@ python feed_generators/<source>_blog.py --full
    feeds_<source>: ## Generate RSS feed for <Source Name>
    	$(call check_venv)
    	$(call print_info,Generating <Source Name> feed)
-   	$(Q)python feed_generators/<source>_blog.py
+   	$(Q)uv run feed_generators/<source>_blog.py
    	$(call print_success,<Source Name> feed generated)
    ```
 
@@ -233,7 +233,7 @@ python feed_generators/<source>_blog.py --full
 Before submitting your PR, verify:
 
 - [ ] `make dev_format` passes (code formatting)
-- [ ] `python feed_generators/<source>_blog.py` runs without errors
+- [ ] `uv run feed_generators/<source>_blog.py` runs without errors
 - [ ] `feeds/feed_<source>.xml` is generated and valid
 - [ ] Make target added to `makefiles/feeds.mk`
 - [ ] README.md table updated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,17 @@ uv sync --group dev
 pre-commit install
 ```
 
+Run `make help` to see all available targets with descriptions.
+
 ## Running Feeds
 
-Run all request-based feeds:
+**Run all request-based feeds:**
 
 ```bash
 uv run feed_generators/run_all_feeds.py --skip-selenium
 ```
 
-Run a single feed:
+**Run a single feed:**
 
 ```bash
 uv run feed_generators/ollama_blog.py
@@ -24,19 +26,18 @@ uv run feed_generators/dagster_blog.py --full  # full reset (all pages)
 
 ## Code Style
 
-This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting, enforced via pre-commit hooks.
+This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting, enforced via pre-commit hooks and a [CI workflow](.github/workflows/lint.yml).
+
+**Check only:**
 
 ```bash
-ruff check .              # lint
-ruff check --fix .        # lint + auto-fix
-ruff format .             # format
+make dev_lint
 ```
 
-Or via Make:
+**Auto-fix + format:**
 
 ```bash
-make dev_lint             # check only
-make dev_lint_fix         # auto-fix + format
+make dev_lint_fix
 ```
 
 ## Adding a New Feed
@@ -46,6 +47,13 @@ See [AGENTS.md](./AGENTS.md) for the complete guide on creating feed generators.
 **Recommended workflow**: Use [Claude Code](https://claude.com/claude-code) with the [Playwright MCP](https://github.com/microsoft/playwright-mcp) to inspect the target site, understand its structure, and generate the scraper.
 
 **When to write a custom scraper**: Only if the site has no official RSS feed, or if a custom parser adds significant value over the official feed (e.g., full content extraction, structured metadata). Simple filtering (e.g., category-only views) does not justify a custom scraper. Check the README for sites that already have official feeds.
+
+### Agent Skills
+
+This repo includes two [Claude Code skills](.agents/skills/) to streamline feed development:
+
+- **`/cmd-rss-feed-generator`** — Generate a new feed scraper from a blog URL or HTML sample. Analyzes the site, picks the right pattern, and scaffolds the generator + Makefile target.
+- **`/rss-feed-review`** — Review feed generators and their XML output for broken selectors, missing error handling, stale feeds, and convention violations.
 
 ## Pull Requests
 

--- a/feed_generators/anthropic_news_blog.py
+++ b/feed_generators/anthropic_news_blog.py
@@ -86,7 +86,7 @@ def fetch_news_content(url=BLOG_URL, max_clicks=20):
                     # Wait for new articles to appear after click
                     with contextlib.suppress(Exception):
                         WebDriverWait(driver, 5).until(
-                            lambda d: len(d.find_elements(By.CSS_SELECTOR, "a[href*='/news/']")) > count_before
+                            lambda d, n=count_before: len(d.find_elements(By.CSS_SELECTOR, "a[href*='/news/']")) > n
                         )
                 else:
                     logger.info(f"No more 'See more' button found after {clicks} clicks")

--- a/feed_generators/anthropic_news_blog.py
+++ b/feed_generators/anthropic_news_blog.py
@@ -79,13 +79,14 @@ def fetch_news_content(url=BLOG_URL, max_clicks=20):
                         )
 
                 if see_more_button and see_more_button.is_displayed():
+                    count_before = len(driver.find_elements(By.CSS_SELECTOR, "a[href*='/news/']"))
                     logger.info(f"Clicking 'See more' button (click {clicks + 1})...")
                     driver.execute_script("arguments[0].click();", see_more_button)
                     clicks += 1
-                    # Wait for new content to load after click
+                    # Wait for new articles to appear after click
                     with contextlib.suppress(Exception):
                         WebDriverWait(driver, 5).until(
-                            lambda d: len(d.find_elements(By.CSS_SELECTOR, "a[href*='/news/']")) > 0
+                            lambda d: len(d.find_elements(By.CSS_SELECTOR, "a[href*='/news/']")) > count_before
                         )
                 else:
                     logger.info(f"No more 'See more' button found after {clicks} clicks")

--- a/feed_generators/anthropic_news_blog.py
+++ b/feed_generators/anthropic_news_blog.py
@@ -1,6 +1,5 @@
 import argparse
 import contextlib
-import time
 import xml.etree.ElementTree as ET
 from datetime import datetime
 
@@ -44,14 +43,9 @@ def fetch_news_content(url=BLOG_URL, max_clicks=20):
         driver = setup_selenium_driver()
         driver.get(url)
 
-        # Wait for initial page load
-        wait_time = 5
-        logger.info(f"Waiting {wait_time} seconds for the page to fully load...")
-        time.sleep(wait_time)
-
         # Wait for news articles to be present
         try:
-            WebDriverWait(driver, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, "a[href*='/news/']")))
+            WebDriverWait(driver, 20).until(EC.presence_of_element_located((By.CSS_SELECTOR, "a[href*='/news/']")))
             logger.info("News articles loaded successfully")
         except Exception:
             logger.warning("Could not confirm articles loaded, proceeding anyway...")
@@ -88,7 +82,11 @@ def fetch_news_content(url=BLOG_URL, max_clicks=20):
                     logger.info(f"Clicking 'See more' button (click {clicks + 1})...")
                     driver.execute_script("arguments[0].click();", see_more_button)
                     clicks += 1
-                    time.sleep(2)  # Wait for content to load
+                    # Wait for new content to load after click
+                    with contextlib.suppress(Exception):
+                        WebDriverWait(driver, 5).until(
+                            lambda d: len(d.find_elements(By.CSS_SELECTOR, "a[href*='/news/']")) > 0
+                        )
                 else:
                     logger.info(f"No more 'See more' button found after {clicks} clicks")
                     break

--- a/feed_generators/claude_blog.py
+++ b/feed_generators/claude_blog.py
@@ -12,6 +12,7 @@ from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
 
 from utils import (
+    deserialize_entries,
     load_cache,
     merge_entries,
     save_cache,
@@ -239,8 +240,9 @@ def main(full_reset=False):
                    and merge with cached posts.
     """
     cache = load_cache(FEED_NAME)
+    cached_entries = deserialize_entries(cache.get("entries", []))
 
-    if full_reset or not cache.get("entries", []):
+    if full_reset or not cached_entries:
         mode = "full reset" if full_reset else "no cache exists"
         logger.info(f"Running full fetch ({mode})")
         posts = fetch_all_pages()
@@ -249,7 +251,7 @@ def main(full_reset=False):
         html_content = fetch_page(BLOG_URL)
         new_posts = parse_posts(html_content)
         logger.info(f"Found {len(new_posts)} posts on page 1")
-        posts = merge_entries(new_posts, cache["entries"])
+        posts = merge_entries(new_posts, cached_entries)
 
     save_cache(FEED_NAME, posts)
     feed = generate_rss_feed(posts)

--- a/feed_generators/dagster_blog.py
+++ b/feed_generators/dagster_blog.py
@@ -44,22 +44,28 @@ def parse_posts(html_content):
         if title_elem and date_elem and link_elem:
             title = title_elem.text.strip()
             date_str = date_elem.text.strip()
-            date_obj = datetime.strptime(date_str, "%B %d, %Y")
-            description = description_elem.text.strip() if description_elem else ""
-            link = link_elem.get("href", "")
+            try:
+                date_obj = datetime.strptime(date_str, "%B %d, %Y")
+            except ValueError:
+                logger.warning(f"Could not parse featured post date: {date_str}")
+                date_obj = None
 
-            if link.startswith("/"):
-                link = f"https://dagster.io{link}"
+            if date_obj:
+                description = description_elem.text.strip() if description_elem else ""
+                link = link_elem.get("href", "")
 
-            if link:
-                blog_posts.append(
-                    {
-                        "link": link,
-                        "title": title,
-                        "date": date_obj.strftime("%Y-%m-%d"),
-                        "description": description,
-                    }
-                )
+                if link.startswith("/"):
+                    link = f"https://dagster.io{link}"
+
+                if link:
+                    blog_posts.append(
+                        {
+                            "link": link,
+                            "title": title,
+                            "date": date_obj.strftime("%Y-%m-%d"),
+                            "description": description,
+                        }
+                    )
 
     # Find all regular blog post cards
     posts = soup.select("div.blog_card")
@@ -74,7 +80,11 @@ def parse_posts(html_content):
         if not date_elem:
             continue
         date_str = date_elem.text.strip()
-        date_obj = datetime.strptime(date_str, "%B %d, %Y")
+        try:
+            date_obj = datetime.strptime(date_str, "%B %d, %Y")
+        except ValueError:
+            logger.warning(f"Could not parse date: {date_str}")
+            continue
 
         description_elem = post.select_one('p[fs-cmsfilter-field="description"]')
         description = description_elem.text.strip() if description_elem else ""

--- a/feed_generators/openai_research_blog.py
+++ b/feed_generators/openai_research_blog.py
@@ -1,10 +1,12 @@
 import argparse
-import time
 from datetime import datetime
 
 import pytz
 from bs4 import BeautifulSoup
 from feedgen.feed import FeedGenerator
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 from utils import (
     deserialize_entries,
@@ -34,9 +36,11 @@ def fetch_news_content_selenium(url):
         driver.get(url)
 
         # Wait for JS-rendered content to load
-        wait_time = 8
-        logger.info(f"Waiting {wait_time} seconds for the page to fully load...")
-        time.sleep(wait_time)
+        try:
+            WebDriverWait(driver, 20).until(EC.presence_of_element_located((By.CSS_SELECTOR, 'a[href^="/index/"]')))
+            logger.info("Research articles loaded successfully")
+        except Exception:
+            logger.warning("Could not confirm articles loaded, proceeding anyway...")
 
         html_content = driver.page_source
         logger.info("Successfully fetched HTML content")

--- a/feed_generators/xainews_blog.py
+++ b/feed_generators/xainews_blog.py
@@ -1,5 +1,4 @@
 import argparse
-import time
 from datetime import datetime
 
 import pytz
@@ -46,9 +45,6 @@ def fetch_news_content(url=BLOG_URL):
             logger.info("News articles loaded successfully")
         except Exception:
             logger.warning("Could not confirm articles loaded, proceeding anyway...")
-
-        # Allow additional time for all dynamic content
-        time.sleep(2)
 
         html_content = driver.page_source
         logger.info("Successfully fetched HTML content")

--- a/makefiles/feeds.mk
+++ b/makefiles/feeds.mk
@@ -6,175 +6,175 @@
 feeds_generate_all: ## Generate all RSS feeds
 	$(call check_venv)
 	$(call print_info_section,Generating all RSS feeds)
-	$(Q)python feed_generators/run_all_feeds.py
+	$(Q)uv run feed_generators/run_all_feeds.py
 	$(call print_success,All feeds generated)
 
 .PHONY: feeds_anthropic_news
 feeds_anthropic_news: ## Generate RSS feed for Anthropic News (incremental)
 	$(call check_venv)
 	$(call print_info,Generating Anthropic News feed)
-	$(Q)python feed_generators/anthropic_news_blog.py
+	$(Q)uv run feed_generators/anthropic_news_blog.py
 	$(call print_success,Anthropic News feed generated)
 
 .PHONY: feeds_anthropic_news_full
 feeds_anthropic_news_full: ## Generate RSS feed for Anthropic News (full reset)
 	$(call check_venv)
 	$(call print_info,Generating Anthropic News feed - FULL RESET)
-	$(Q)python feed_generators/anthropic_news_blog.py --full
+	$(Q)uv run feed_generators/anthropic_news_blog.py --full
 	$(call print_success,Anthropic News feed generated - full reset)
 
 .PHONY: feeds_anthropic_engineering
 feeds_anthropic_engineering: ## Generate RSS feed for Anthropic Engineering
 	$(call check_venv)
 	$(call print_info,Generating Anthropic Engineering feed)
-	$(Q)python feed_generators/anthropic_eng_blog.py
+	$(Q)uv run feed_generators/anthropic_eng_blog.py
 	$(call print_success,Anthropic Engineering feed generated)
 
 .PHONY: feeds_anthropic_research
 feeds_anthropic_research: ## Generate RSS feed for Anthropic Research
 	$(call check_venv)
 	$(call print_info,Generating Anthropic Research feed)
-	$(Q)python feed_generators/anthropic_research_blog.py
+	$(Q)uv run feed_generators/anthropic_research_blog.py
 	$(call print_success,Anthropic Research feed generated)
 
 .PHONY: feeds_anthropic_changelog_claude_code
 feeds_anthropic_changelog_claude_code: ## Generate RSS feed for Anthropic Claude Code changelog
 	$(call check_venv)
 	$(call print_info,Generating Claude Code changelog feed)
-	$(Q)python feed_generators/anthropic_changelog_claude_code.py
+	$(Q)uv run feed_generators/anthropic_changelog_claude_code.py
 	$(call print_success,Claude Code changelog feed generated)
 
 .PHONY: feeds_anthropic_red
 feeds_anthropic_red: ## Generate RSS feed for Anthropic Frontier Red Team
 	$(call check_venv)
 	$(call print_info,Generating Anthropic Red Team feed)
-	$(Q)python feed_generators/anthropic_red_blog.py
+	$(Q)uv run feed_generators/anthropic_red_blog.py
 	$(call print_success,Anthropic Red Team feed generated)
 
 .PHONY: feeds_google_ai
 feeds_google_ai: ## Generate RSS feed for Google AI Blog
 	$(call check_venv)
 	$(call print_info,Generating Google AI feed)
-	$(Q)python feed_generators/google_ai_blog.py
+	$(Q)uv run feed_generators/google_ai_blog.py
 	$(call print_success,Google AI feed generated)
 
 .PHONY: feeds_openai_research
 feeds_openai_research: ## Generate RSS feed for OpenAI Research
 	$(call check_venv)
 	$(call print_info,Generating OpenAI Research feed)
-	$(Q)python feed_generators/openai_research_blog.py
+	$(Q)uv run feed_generators/openai_research_blog.py
 	$(call print_success,OpenAI Research feed generated)
 
 .PHONY: feeds_ollama
 feeds_ollama: ## Generate RSS feed for Ollama Blog
 	$(call check_venv)
 	$(call print_info,Generating Ollama Blog feed)
-	$(Q)python feed_generators/ollama_blog.py
+	$(Q)uv run feed_generators/ollama_blog.py
 	$(call print_success,Ollama Blog feed generated)
 
 .PHONY: feeds_paulgraham
 feeds_paulgraham: ## Generate RSS feed for Paul Graham's articles
 	$(call check_venv)
 	$(call print_info,Generating Paul Graham feed)
-	$(Q)python feed_generators/paulgraham_blog.py
+	$(Q)uv run feed_generators/paulgraham_blog.py
 	$(call print_success,Paul Graham feed generated)
 
 .PHONY: feeds_blogsurgeai
 feeds_blogsurgeai: ## Generate RSS feed for Surge AI Blog
 	$(call check_venv)
 	$(call print_info,Generating Surge AI Blog feed)
-	$(Q)python feed_generators/blogsurgeai_feed_generator.py
+	$(Q)uv run feed_generators/blogsurgeai_feed_generator.py
 	$(call print_success,Surge AI Blog feed generated)
 
 .PHONY: feeds_xainews
 feeds_xainews: ## Generate RSS feed for xAI News
 	$(call check_venv)
 	$(call print_info,Generating xAI News feed)
-	$(Q)python feed_generators/xainews_blog.py
+	$(Q)uv run feed_generators/xainews_blog.py
 	$(call print_success,xAI News feed generated)
 
 .PHONY: feeds_chanderramesh
 feeds_chanderramesh: ## Generate RSS feed for Chander Ramesh's writing
 	$(call check_venv)
 	$(call print_info,Generating Chander Ramesh feed)
-	$(Q)python feed_generators/chanderramesh_blog.py
+	$(Q)uv run feed_generators/chanderramesh_blog.py
 	$(call print_success,Chander Ramesh feed generated)
 
 .PHONY: feeds_claude
 feeds_claude: ## Generate RSS feed for Claude Blog (incremental)
 	$(call check_venv)
 	$(call print_info,Generating Claude Blog feed)
-	$(Q)python feed_generators/claude_blog.py
+	$(Q)uv run feed_generators/claude_blog.py
 	$(call print_success,Claude Blog feed generated)
 
 .PHONY: feeds_claude_full
 feeds_claude_full: ## Generate RSS feed for Claude Blog (full reset)
 	$(call check_venv)
 	$(call print_info,Generating Claude Blog feed - FULL RESET)
-	$(Q)python feed_generators/claude_blog.py --full
+	$(Q)uv run feed_generators/claude_blog.py --full
 	$(call print_success,Claude Blog feed generated - full reset)
 
 .PHONY: feeds_thinkingmachines
 feeds_thinkingmachines: ## Generate RSS feed for Thinking Machines Lab blog
 	$(call check_venv)
 	$(call print_info,Generating Thinking Machines Lab feed)
-	$(Q)python feed_generators/thinkingmachines_blog.py
+	$(Q)uv run feed_generators/thinkingmachines_blog.py
 	$(call print_success,Thinking Machines Lab feed generated)
 
 .PHONY: feeds_hamel
 feeds_hamel: ## Generate RSS feed for Hamel Husain's Blog
 	$(call check_venv)
 	$(call print_info,Generating Hamel Husain Blog feed)
-	$(Q)python feed_generators/hamel_blog.py
+	$(Q)uv run feed_generators/hamel_blog.py
 	$(call print_success,Hamel Husain Blog feed generated)
 
 .PHONY: feeds_cursor
 feeds_cursor: ## Generate RSS feed for Cursor Blog (incremental)
 	$(call check_venv)
 	$(call print_info,Generating Cursor Blog feed)
-	$(Q)python feed_generators/cursor_blog.py
+	$(Q)uv run feed_generators/cursor_blog.py
 	$(call print_success,Cursor Blog feed generated)
 
 .PHONY: feeds_cursor_full
 feeds_cursor_full: ## Generate RSS feed for Cursor Blog (full reset)
 	$(call check_venv)
 	$(call print_info,Generating Cursor Blog feed - FULL RESET)
-	$(Q)python feed_generators/cursor_blog.py --full
+	$(Q)uv run feed_generators/cursor_blog.py --full
 	$(call print_success,Cursor Blog feed generated - full reset)
 
 .PHONY: feeds_windsurf_blog
 feeds_windsurf_blog: ## Generate RSS feed for Windsurf Blog
 	$(call check_venv)
 	$(call print_info,Generating Windsurf Blog feed)
-	$(Q)python feed_generators/windsurf_blog.py
+	$(Q)uv run feed_generators/windsurf_blog.py
 	$(call print_success,Windsurf Blog feed generated)
 
 .PHONY: feeds_windsurf_changelog
 feeds_windsurf_changelog: ## Generate RSS feed for Windsurf Changelog
 	$(call check_venv)
 	$(call print_info,Generating Windsurf Changelog feed)
-	$(Q)python feed_generators/windsurf_changelog.py
+	$(Q)uv run feed_generators/windsurf_changelog.py
 	$(call print_success,Windsurf Changelog feed generated)
 
 .PHONY: feeds_windsurf_next_changelog
 feeds_windsurf_next_changelog: ## Generate RSS feed for Windsurf Next Changelog
 	$(call check_venv)
 	$(call print_info,Generating Windsurf Next Changelog feed)
-	$(Q)python feed_generators/windsurf_next_changelog.py
+	$(Q)uv run feed_generators/windsurf_next_changelog.py
 	$(call print_success,Windsurf Next Changelog feed generated)
 
 .PHONY: feeds_the_batch
 feeds_the_batch: ## Generate RSS feed for The Batch by DeepLearning.AI
 	$(call check_venv)
 	$(call print_info,Generating The Batch feed)
-	$(Q)python feed_generators/deeplearningai_the_batch.py
+	$(Q)uv run feed_generators/deeplearningai_the_batch.py
 	$(call print_success,The Batch feed generated)
 
 .PHONY: feeds_dagster
 feeds_dagster: ## Generate RSS feed for Dagster Blog
 	$(call check_venv)
 	$(call print_info,Generating Dagster Blog feed)
-	$(Q)python feed_generators/dagster_blog.py
+	$(Q)uv run feed_generators/dagster_blog.py
 	$(call print_success,Dagster Blog feed generated)
 
 .PHONY: clean_feeds


### PR DESCRIPTION
_tl;dr Fix generator bugs, replace `time.sleep` with proper Selenium waits, and migrate all remaining bare `python` calls to `uv run`._

## Summary

- **Fix `claude_blog.py` cache bug**: Add missing `deserialize_entries()` call — cached ISO date strings weren't converted back to datetimes before merge/sort
- **Fix `dagster_blog.py` crash**: Wrap bare `strptime` calls in try/except so unexpected date formats log a warning instead of crashing the generator
- **Replace `time.sleep` with `WebDriverWait`**: Swap fixed sleeps for explicit waits in `anthropic_news_blog.py`, `openai_research_blog.py`, and `xainews_blog.py`
- **Migrate to `uv run`**: Replace all 26 bare `python` calls in `feeds.mk`, fix `validate_feeds.yml` to install uv, update `AGENTS.md` and skill docs
- **Improve `CONTRIBUTING.md`**: Add `make help` callout, link to lint CI workflow, document agent skills

## Feature Diff

| S    | Component                    | Before                                          | After                                                     |
| ---- | ---------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
| 🔴 | `claude_blog.py` cache merge | Raw cache dict passed to `merge_entries()`       | `deserialize_entries()` called first — fixes string sorting |
| 🔴 | `dagster_blog.py` date parse | Bare `strptime` — crashes on unexpected format   | Wrapped in try/except with warning log                     |
| 🟡 | `anthropic_news_blog.py`     | `time.sleep(5)` + `time.sleep(2)` for waits      | `WebDriverWait` with article count increase check          |
| 🟡 | `openai_research_blog.py`    | `time.sleep(8)` for page load                    | `WebDriverWait` for `a[href^="/index/"]` selector          |
| 🟡 | `xainews_blog.py`            | Redundant `time.sleep(2)` after `WebDriverWait`  | Removed — `WebDriverWait` already handles it               |
| ⚙️ | `makefiles/feeds.mk`        | `$(Q)python feed_generators/...`                | `$(Q)uv run feed_generators/...`                          |
| ⚙️ | `validate_feeds.yml`         | Bare `python`, no `uv` setup                    | Installs `uv`, runs `uv sync` + `uv run`                 |
| ⚪ | `AGENTS.md`                  | References bare `python`                         | All examples use `uv run`                                  |
| ⚪ | `CONTRIBUTING.md`            | No `make help` reference, no skills section      | Added `make help`, lint CI link, agent skills section       |

> 🔴 Critical fix · 🟡 Improvement · 🟢 New feature · ⚪ Neutral · ⚙️ Infra/tooling · ⚠️ Breaking

## Details

<details>
<summary>Technical Details</summary>

### Generator Bug Fixes

- **`claude_blog.py:241-253`**: Cache entries were passed as raw dicts (with ISO string dates) to `merge_entries()`, which sorts by date — strings don't sort correctly as datetimes. Added `deserialize_entries()` call.
- **`dagster_blog.py:47,80`**: `datetime.strptime(date_str, "%B %d, %Y")` called without exception handling — crashes if format changes. Featured post now sets `date_obj = None` on failure and skips; regular posts `continue` on failure.

### Selenium Wait Improvements

- **`anthropic_news_blog.py`**: Removed redundant `time.sleep(5)` before existing `WebDriverWait`. Replaced `time.sleep(2)` between "See more" clicks with `WebDriverWait` that checks article count *increase* (not just presence). Uses `lambda d, n=count_before` to bind the count correctly.
- **`openai_research_blog.py`**: Replaced `time.sleep(8)` with `WebDriverWait(driver, 20)` targeting `a[href^="/index/"]` elements. Added `selenium.webdriver` imports.
- **`xainews_blog.py`**: Removed `time.sleep(2)` that followed an existing `WebDriverWait` — the wait already ensures content is loaded.

### `uv run` Migration

- **`feeds.mk`**: All 26 `$(Q)python` → `$(Q)uv run`
- **`validate_feeds.yml`**: Added `astral-sh/setup-uv@v8.0.0` + `uv sync` steps
- **`AGENTS.md`**: Updated code examples and PR checklist
- **`cmd-rss-feed-generator/SKILL.md`**: Updated template commands

</details>
