### PR TITLE
feed_meta_ai: fix hero post being mis-dated to a stable_fallback_date

### DIFF
--- a/feed_generators/meta_ai_blog.py
+++ b/feed_generators/meta_ai_blog.py
@@ -169,10 +169,24 @@ def extract_articles(soup: BeautifulSoup) -> list[dict]:
                 aria = link.get("aria-label", "")
                 title = aria.removeprefix("Read ").strip() if aria.startswith("Read ") else ""
             if title:
-                date_elem = hero.find("div", class_="_amdj")
-                date, _ = _extract_date_from_elements([date_elem] if date_elem else [], href)
-                cat_elem = hero.find("div", class_="_amug")
-                category = cat_elem.get_text(strip=True) if cat_elem else "AI"
+                # The hero's date container class has rotated (was _amdj, then
+                # _amun, ...), so scan every <div> inside the hero with the
+                # DATE_PATTERN regex instead of pinning to a single class.
+                # Without this we fall through to stable_fallback_date(), which
+                # (relying on Python's randomized hash()) buries the newest
+                # post under a bogus pubDate.
+                date, _ = _extract_date_from_elements(hero.find_all("div"), href)
+
+                # Category: try the legacy explicit class, then the current
+                # "FEATURED"-style badge, then default. Empty strings are
+                # treated as missing so we don't emit empty <category/>.
+                category = "AI"
+                for cls in ("_amug", "_amd5"):
+                    cat_elem = hero.find("div", class_=cls)
+                    cat_text = cat_elem.get_text(strip=True) if cat_elem else ""
+                    if cat_text:
+                        category = cat_text.title() if cat_text.isupper() else cat_text
+                        break
                 _append_article(articles, seen, href, title, date, category, title)
 
     # Latest News grid (div._amda)


### PR DESCRIPTION
Closes #86.

## Summary

The newest post on https://ai.meta.com/blog/ is the hero card at the top of the page. The Meta AI scraper was *capturing* the hero, but its date and category lookups were pinned to specific hashed CSS-module class names that have since rotated:

| Field | Was | Now |
|---|---|---|
| Date | `div._amdj` | `div._amun` (\"April 8, 2026\") |
| Category | `div._amug` (now empty) | `div._amd5` (\"FEATURED\" badge) |

When the date lookup returned `None`, `_append_article` fell back to `utils.stable_fallback_date(href)`, which emitted a bogus pubDate (\"Wed, 22 May 2024\" in the current `feed_meta_ai.xml`) — so the newest post landed buried beneath ~3 weeks of older posts and looked \"missing\" to subscribers.

## Fix

Narrow change to the hero block of `extract_articles` only — the `_amda` and `_amsu` layouts still match their existing selectors today, so they're untouched.

- **Date**: feed *every* `<div>` inside the hero into the existing `_extract_date_from_elements` helper and let `DATE_PATTERN` find the date regardless of which class wraps it. Class-agnostic, will survive the next rotation.
- **Category**: try `_amug` first (legacy), then `_amd5` (the current \"FEATURED\" badge — title-cased so the rendered feed reads \"Featured\" rather than yelling \"FEATURED\"), then default to `\"AI\"`. Empty values are treated as missing so the feed doesn't emit `<category></category>`.

## Verification

Selenium can't run locally on Python 3.13 because `undetected-chromedriver` imports `distutils` (separate issue), so I exercised the parser directly against the captured page HTML:

```text
$ curl -sL https://ai.meta.com/blog/ -o /tmp/meta_blog.html
$ python -c \"from bs4 import BeautifulSoup; from meta_ai_blog import extract_articles; \\
   print(extract_articles(BeautifulSoup(open('/tmp/meta_blog.html').read(), 'html.parser')))\"
```

Before the fix:
- Hero (\"Introducing Muse Spark\") added with `date=None` → `stable_fallback_date(href)` (random-ish 2023–2024 date), `category=\"\"`.

After the fix:
- Hero added with `date=2026-04-08`, `category=\"Featured\"`. Sorted at the top of the article list.

Console output of `extract_articles` against the live HTML, post-fix:

```
Total: 5 articles
  2026-04-08  cat=Featured           Introducing Muse Spark: Scaling Towards Personal Superintelligence
  2026-04-08  cat=Research           Scaling How We Build and Test Our Most Advanced AI
  2026-04-06  cat=Computer Vision    How Alta Daily Uses Meta's Segment Anything to Reimagine the Digital Closet
  2026-03-27  cat=Computer Vision    SAM 3.1: Faster and More Accessible Real-Time Video Detection and Tracking …
  2026-03-11  cat=AI                 Four MTIA Chips in Two Years: Scaling AI Experiences for Billions
```

## Test plan

- [x] `make dev_lint` passes (`32 files already formatted`, `All checks passed!`)
- [x] Hero post extracted with the real publication date and a non-empty category
- [x] Latest News (`_amda`) and \"More from AI at Meta\" (`_amsu`) layouts unchanged

## Out of scope (flagged in #86)

`utils.stable_fallback_date()` is keyed on Python's built-in `hash()`, which is randomized per process via `PYTHONHASHSEED`. Its \"stable\" date is in fact non-deterministic across runs, which is what made this bug *visible* (the pubDate would shift every hourly run). Worth a separate look — happy to send a follow-up PR if you'd like.